### PR TITLE
Payloads only objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a signer function by calling `createSigner` and providing one or more of 
 
 The signer is a function which accepts a payload and returns the token.
 
-The payload must be a object, a buffer or a string. If not a object, all the options of the signer which modify the the payload will be ignored. If `iat` claim is already present, it won't be overwritten with the current timestamp.
+The payload must be an object.
 
 If the `key` option is a function, the signer will also accept a Node style callback and will return a promise, supporting therefore both callback and async/await styles.
 
@@ -76,7 +76,6 @@ async function test() {
 Create a decoder function by calling `createDecoder` and providing one or more of the following options:
 
 - `complete`: Return an object with the decoded header, payload, signature and input (the token part before the signature), instead of just the content of the payload. Default is `false`.
-- `json`: Always parse the payload as JSON even if the `typ` claim of the header is not `JWT`. Default is `true`.
 
 The decoder is a function which accepts a token (as Buffer or string) and returns the payload or the sections of the token.
 
@@ -112,7 +111,6 @@ Create a verifier function by calling `createVerifier` and providing one or more
 - `key`: A string or a buffer containing the secret for `HS*` algorithms or the PEM encoded public key for `RS*`, `PS*`, `ES*` and `EdDSA` algorithms. The key can also be a function accepting a Node style callback or a function returning a promise. This is the only mandatory option, which must NOT be provided if the token algorithm is `none`.
 - `algorithms`: List of strings with the names of the allowed algorithms. By default, all algorithms are accepted.
 - `complete`: Return an object with the decoded header, payload, signature and input (the token part before the signature), instead of just the content of the payload. Default is `false`.
-- `json`: Always parse the payload as JSON even if the `typ` claim of the header is not `JWT`. Default is `true`.
 - `cache`: A positive number specifying the size of the verified tokens cache (using LRU strategy). Setting to `true` is equivalent to provide the size `1000`. When enabled, as you can see in the benchmarks section below, performances dramatically improve. By default the cache is disabled.
 - `cacheTTL`: The maximum time to live of a cache entry (in milliseconds). If the token has a earlier expiration or the verifier has a shorter `maxAge`, the earlier takes precedence. The default is `600000`, which is 10 minutes.
 - `allowedJti`: A string, a regular expression, an array of strings or an array of regular expressions containing allowed values for the id claim (`jti`). By default, all values are accepted.

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -321,7 +321,6 @@ module.exports = function createVerifier(options) {
   let {
     key,
     algorithms: allowedAlgorithms,
-    json,
     complete,
     cache: cacheSize,
     cacheTTL,
@@ -424,7 +423,7 @@ module.exports = function createVerifier(options) {
     maxAge,
     isAsync: keyType === 'function',
     validators,
-    decode: createDecoder({ json, complete: true }),
+    decode: createDecoder({ complete: true }),
     cache: createCache(cacheSize)
   }
 

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -5,7 +5,7 @@ const { test } = require('tap')
 const { createDecoder } = require('../src')
 
 const defaultDecoder = createDecoder()
-const rawDecoder = createDecoder({ json: false })
+// const rawDecoder = createDecoder({ json: false })
 const completeDecoder = createDecoder({ complete: true })
 
 const token =
@@ -30,9 +30,6 @@ test('should return a valid token', t => {
     input: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ik9LIiwiaWF0Ijo5ODc2NTQzMjEwfQ'
   })
 
-  t.strictDeepEqual(defaultDecoder(nonJwtToken), { sub: '1234567890', name: 'OK', iat: 9876543210 })
-  t.strictDeepEqual(rawDecoder(nonJwtToken), '{"sub":"1234567890","name":"OK","iat":9876543210}')
-
   t.end()
 })
 
@@ -56,6 +53,8 @@ test('invalid header', t => {
   t.throws(() => defaultDecoder('a.b.c'), { message: 'The token header is not a valid base64url serialized JSON.' })
 
   t.throws(() => defaultDecoder('Zm9v.b.c'), { message: 'The token header is not a valid base64url serialized JSON.' })
+
+  t.throws(() => defaultDecoder(nonJwtToken), { message: 'The type must be JWT.' })
 
   t.end()
 })

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -45,13 +45,6 @@ test('it correctly returns a token - sync', t => {
     'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhIjoxfQ.'
   )
 
-  t.equal(sign('123', { noTimestamp: true }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
-
-  t.equal(
-    sign(Buffer.from('123', 'utf-8'), { noTimestamp: true }),
-    'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA'
-  )
-
   t.equal(
     sign({ a: 1 }, { noTimestamp: true, algorithm: 'none', key: null }),
     'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhIjoxfQ.'
@@ -190,8 +183,6 @@ test('it adds a exp claim, overriding the payload one, only if the payload is a 
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoxMDF9.ULKqTsvUYm7iNOKA6bP5NXsa1A8vofgPIGiC182Vf_Q'
   )
 
-  t.equal(sign('123', { expiresIn: 1000 }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
-
   t.end()
 })
 
@@ -206,8 +197,6 @@ test('it adds a nbf claim, overriding the payload one, only if the payload is a 
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwibmJmIjoxMDF9.WhZeNowse7q1s5FSlcMcs_4KcxXpSdQ4yqv0xrGB3sU'
   )
 
-  t.equal(sign('123', { notBefore: 1000 }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
-
   t.end()
 })
 
@@ -221,8 +210,6 @@ test('it adds a jti claim, overriding the payload one, only if the payload is a 
     sign({ a: 1, jti: 'original' }, { jti: 'JTI', noTimestamp: true }),
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkifQ.Ew1eS3Pn9R0hqV0JCA5AECTSvaEm9glggxWlmq0cYl4'
   )
-
-  t.equal(sign('123', { jti: 'JTI' }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
 
   t.end()
 })
@@ -243,8 +230,6 @@ test('it adds a aud claim, overriding the payload one, only if the payload is a 
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJhdWQiOlsiQVVEMSIsIkFVRDIiXX0.zRcmqvl1hRzaWa8qX_ge7mHeJNSH-Th-TLu0-62jFxc'
   )
 
-  t.equal(sign('123', { aud: 'AUD1' }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
-
   t.end()
 })
 
@@ -258,8 +243,6 @@ test('it adds a iss claim, overriding the payload one, only if the payload is a 
     sign({ a: 1, iss: 'original' }, { iss: 'ISS', noTimestamp: true }),
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpc3MiOiJJU1MifQ.YLEisGRTlJL9Y7KLHbIahXr1Zqu0of5w1mJf4aGphTE'
   )
-
-  t.equal(sign('123', { iss: 'ISS' }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
 
   t.end()
 })
@@ -275,8 +258,6 @@ test('it adds a sub claim, overriding the payload one, only if the payload is a 
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJzdWIiOiJTVUIifQ.wweP9vNGt77bBGwZ_PLXfPxy2qcx2mnjUa0AWVA5bEM'
   )
 
-  t.equal(sign('123', { sub: 'SUB' }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
-
   t.end()
 })
 
@@ -290,8 +271,6 @@ test('it adds a nonce claim, overriding the payload one, only if the payload is 
     sign({ a: 1, nonce: 'original' }, { nonce: 'NONCE', noTimestamp: true }),
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJub25jZSI6Ik5PTkNFIn0.NvCriFYuVDq0fTSf5t_92EwbxnwgjZVMBEMfW-RVl_k'
   )
-
-  t.equal(sign('123', { nonce: 'NONCE' }), 'eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA')
 
   t.end()
 })
@@ -414,8 +393,8 @@ test('it correctly handle errors - evented callback', t => {
 })
 
 test('returns a promise according to key option', t => {
-  const s1 = createSigner({ key: 'secret' })('PAYLOAD')
-  const s2 = createSigner({ key: async () => 'secret' })('PAYLOAD')
+  const s1 = createSigner({ key: 'secret' })({ a: 'PAYLOAD' })
+  const s2 = createSigner({ key: async () => 'secret' })({ a: 'PAYLOAD' })
 
   t.true(typeof s1.then === 'undefined')
   t.true(typeof s2.then === 'function')

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -56,7 +56,7 @@ test('it correctly verifies a token - sync', t => {
   t.throws(() => {
     verify('eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA', { noTimestamp: true })
   }, {
-    code: 'FAST_JWT_INVALID_PAYLOAD'
+    code: 'FAST_JWT_INVALID_TYPE'
   })
 
   t.strictDeepEqual(


### PR DESCRIPTION
The JWT spec mandates that the payloads MUST be objects (#33) 

From: https://tools.ietf.org/html/rfc7519#section-7.2

> 10. Verify that the resulting octet sequence is a UTF-8-encoded
> representation of a completely valid JSON object conforming to
> RFC 7159 [RFC7159]; let the JWT Claims Set be this JSON object.

- adjusted the decoder, signer and verifier to make sure that the payloads are only of type object.
- adjusted the tests to reflect the changes
- updated the docs
