### PR TITLE
Adjustments to get full test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "scripts": {
     "prepublishOnly": "npm run ci",
     "postpublish": "git push origin && git push origin -f --tags",
-    "ci": "npm run lint && tap --no-color --reporter=spec --coverage-report=json --coverage-report=text --branches 90 --functions 90 --lines 90 --statements 90 test/*.spec.js test/**/*.spec.js",
+    "ci": "npm run lint && tap --no-color --reporter=spec --coverage-report=json --coverage-report=text --100 test/*.spec.js test/**/*.spec.js",
     "lint": "eslint src/**/*.js test/**/*.js",
-    "test": "tap --reporter=spec --coverage-report=html --coverage-report=text --no-browser test/*.spec.js test/**/*.spec.js",
+    "test": "tap --reporter=spec --coverage-report=html --coverage-report=text --100 --no-browser test/*.spec.js test/**/*.spec.js",
     "test:watch": "tap --watch --reporter=spec --coverage-report=html --coverage-report=text --no-browser test/*.spec.js test/**/*.spec.js",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",
     "test:generate-tokens": "node benchmarks/keys/generate-tokens.js",

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -112,7 +112,7 @@ function handleCachedResult(cached, callback, promise) {
 
 function validateAlgorithmAndSignature(input, header, signature, key, allowedAlgorithms) {
   // According to the signature and key, check with algorithms are supported
-  const algorithms = allowedAlgorithms.length ? allowedAlgorithms : detectPublicKeyAlgorithms(key)
+  const algorithms = allowedAlgorithms
 
   // Verify the token is allowed
   if (!algorithms.includes(header.alg)) {

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -207,6 +207,12 @@ for (const type of ['Ed25519', 'Ed448']) {
   })
 }
 
+test('detectPublicKeyAlgorithms - empty key should return "none"', t => {
+  t.equals(detectPublicKeyAlgorithms(), 'none')
+
+  t.end()
+})
+
 test('detectPublicKeyAlgorithms - malformed or key objects must be rejected', t => {
   t.throws(() => detectPublicKeyAlgorithms({}), {
     message: 'The public key must be a string or a buffer.'


### PR DESCRIPTION
Makes some adjustments in code and tests to get full test coverage.
From issue #32 

- test `detectPublicKeyAlgorithms` output `none`
- remove duplicate check on `allowedAlgorithms` in `validateAlgorithmAndSignature`. this is a private function that's been called from `createVerifier` where the same check has already been done, causing this code never to be hit.
- force full code test coverage