### PR TITLE
Removes undefined props

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -268,6 +268,9 @@ module.exports = function createSigner(options) {
     throw new TokenError(TokenError.codes.invalidOption, 'The header option must be a object.')
   }
 
+  const fpo = { jti, aud, iss, sub, nonce }
+  const fixedPayload = Object.keys(fpo).reduce((obj, key) => { return (fpo[key] !== undefined) ? Object.assign(obj, { [key]: fpo[key] }) : obj }, {})
+
   // Return the signer
   const context = {
     key,
@@ -280,13 +283,7 @@ module.exports = function createSigner(options) {
     kid,
     isAsync: keyType === 'function',
     additionalHeader,
-    fixedPayload: JSON.parse(JSON.stringify({
-      jti,
-      aud,
-      iss,
-      sub,
-      nonce
-    }))
+    fixedPayload
   }
 
   return sign.bind(null, context)

--- a/src/signer.js
+++ b/src/signer.js
@@ -280,13 +280,13 @@ module.exports = function createSigner(options) {
     kid,
     isAsync: keyType === 'function',
     additionalHeader,
-    fixedPayload: {
+    fixedPayload: JSON.parse(JSON.stringify({
       jti,
       aud,
       iss,
       sub,
       nonce
-    }
+    }))
   }
 
   return sign.bind(null, context)

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -163,6 +163,15 @@ test('it respect the payload iat, if one is set', t => {
   t.end()
 })
 
+test('it respect the payload sub, if one is set', t => {
+  t.equal(
+    sign({ a: 1, sub: 'SUB' }, { noTimestamp: true }),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJzdWIiOiJTVUIifQ.wweP9vNGt77bBGwZ_PLXfPxy2qcx2mnjUa0AWVA5bEM'
+  )
+
+  t.end()
+})
+
 test('it uses the clockTimestamp option, if one is set', t => {
   t.equal(
     sign({ a: 1 }, { clockTimestamp: 123000 }),


### PR DESCRIPTION
The payload options provided by `createSigner` should overwrite the ones in the payload that needs to be signed.
But when the options are **not** provided to the `createSigner` function, they are always `undefined` when property merge occurs. This overwrites the properties of the payload provided in `sign` with empty values as in issue #38 . 
This changes clears the `fixedProperties` from empty values before merging.