### PR TITLE
Header typ check

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ async function test() {
 Create a decoder function by calling `createDecoder` and providing one or more of the following options:
 
 - `complete`: Return an object with the decoded header, payload, signature and input (the token part before the signature), instead of just the content of the payload. Default is `false`.
+- `skipTypCheck`: When validating the decoded header, setting this option skips the check of the `typ` property. This would be neccesary for AWS Cognito tokens, that do not send `typ` as part of the header. Default is `false`.
 
 The decoder is a function which accepts a token (as Buffer or string) and returns the payload or the sections of the token.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ async function test() {
 Create a decoder function by calling `createDecoder` and providing one or more of the following options:
 
 - `complete`: Return an object with the decoded header, payload, signature and input (the token part before the signature), instead of just the content of the payload. Default is `false`.
-- `skipTypCheck`: When validating the decoded header, setting this option skips the check of the `typ` property. This would be neccesary for AWS Cognito tokens, that do not send `typ` as part of the header. Default is `false`.
+- `checkTyp`: When validating the decoded header, setting this option forces the check of the `typ` property against this value. Example: `checkTyp: 'JWT'`. Default is `undefined`.
 
 The decoder is a function which accepts a token (as Buffer or string) and returns the payload or the sections of the token.
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -2,7 +2,7 @@
 
 const TokenError = require('./error')
 
-function decode({ complete }, token) {
+function decode({ complete, skipTypCheck }, token) {
   // Make sure the token is a string or a Buffer - Other cases make no sense to even try to validate
   if (token instanceof Buffer) {
     token = token.toString('utf-8')
@@ -22,7 +22,7 @@ function decode({ complete }, token) {
   let validHeader = false
   try {
     const header = JSON.parse(Buffer.from(token.slice(0, firstSeparator), 'base64').toString('utf-8'))
-    if (header.typ !== 'JWT') {
+    if (!skipTypCheck && header.typ !== 'JWT') {
       throw new TokenError(TokenError.codes.invalidType, 'The type must be JWT.', { header })
     }
     validHeader = true
@@ -54,6 +54,7 @@ function decode({ complete }, token) {
 
 module.exports = function createDecoder(options = {}) {
   const complete = options.complete || false
+  const skipTypCheck = options.skipTypCheck || false
 
-  return decode.bind(null, { complete })
+  return decode.bind(null, { complete, skipTypCheck })
 }

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -2,7 +2,7 @@
 
 const TokenError = require('./error')
 
-function decode({ complete, skipTypCheck }, token) {
+function decode({ complete, checkTyp }, token) {
   // Make sure the token is a string or a Buffer - Other cases make no sense to even try to validate
   if (token instanceof Buffer) {
     token = token.toString('utf-8')
@@ -22,8 +22,8 @@ function decode({ complete, skipTypCheck }, token) {
   let validHeader = false
   try {
     const header = JSON.parse(Buffer.from(token.slice(0, firstSeparator), 'base64').toString('utf-8'))
-    if (!skipTypCheck && header.typ !== 'JWT') {
-      throw new TokenError(TokenError.codes.invalidType, 'The type must be JWT.', { header })
+    if (checkTyp && header.typ !== checkTyp) {
+      throw new TokenError(TokenError.codes.invalidType, `The type must be "${checkTyp}".`, { header })
     }
     validHeader = true
 
@@ -54,7 +54,7 @@ function decode({ complete, skipTypCheck }, token) {
 
 module.exports = function createDecoder(options = {}) {
   const complete = options.complete || false
-  const skipTypCheck = options.skipTypCheck || false
+  const checkTyp = options.checkTyp
 
-  return decode.bind(null, { complete, skipTypCheck })
+  return decode.bind(null, { complete, checkTyp })
 }

--- a/src/signer.js
+++ b/src/signer.js
@@ -62,6 +62,7 @@ function sign(
     expiresIn,
     notBefore,
     kid,
+    typ,
     isAsync,
     additionalHeader,
     fixedPayload
@@ -79,7 +80,7 @@ function sign(
   // Prepare the header
   const header = {
     alg: algorithm,
-    typ: 'JWT',
+    typ: typ || 'JWT',
     kid,
     ...additionalHeader
   }
@@ -180,6 +181,7 @@ module.exports = function createSigner(options) {
     sub,
     nonce,
     kid,
+    typ,
     header: additionalHeader
   } = { clockTimestamp: 0, ...options }
 
@@ -281,6 +283,7 @@ module.exports = function createSigner(options) {
     expiresIn,
     notBefore,
     kid,
+    typ,
     isAsync: keyType === 'function',
     additionalHeader,
     fixedPayload

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -324,6 +324,7 @@ module.exports = function createVerifier(options) {
     complete,
     cache: cacheSize,
     cacheTTL,
+    checkTyp,
     clockTimestamp,
     clockTolerance,
     ignoreExpiration,

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -324,7 +324,6 @@ module.exports = function createVerifier(options) {
     complete,
     cache: cacheSize,
     cacheTTL,
-    checkTyp,
     clockTimestamp,
     clockTolerance,
     ignoreExpiration,

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -172,9 +172,11 @@ function verifyToken(
   validateAlgorithmAndSignature(input, header, signature, key, allowedAlgorithms)
 
   // Verify typ
-  const headerTyp = (header.typ || '').toLowerCase().replace(/^application\//, '')
-  if (checkTyp && (checkTyp !== headerTyp)) {
-    throw new TokenError(TokenError.codes.invalidType, 'Invalid typ.')
+  if (checkTyp) {
+    const headerTyp = (header.typ || '').toLowerCase().replace(/^application\//, '')
+    if (checkTyp !== headerTyp) {
+      throw new TokenError(TokenError.codes.invalidType, 'Invalid typ.')
+    }
   }
 
   // Verify the payload

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -157,7 +157,7 @@ function validateClaimValue(value, modifier, now, greater, errorCode, errorVerb)
 function verifyToken(
   key,
   { input, header, payload, signature },
-  { validators, allowedAlgorithms, clockTimestamp, clockTolerance }
+  { validators, allowedAlgorithms, checkTyp, clockTimestamp, clockTolerance }
 ) {
   // Verify the key
   /* istanbul ignore next */
@@ -170,6 +170,12 @@ function verifyToken(
   }
 
   validateAlgorithmAndSignature(input, header, signature, key, allowedAlgorithms)
+
+  // Verify typ
+  const headerTyp = (header.typ || '').toLowerCase().replace(/^application\//, '')
+  if (checkTyp && (checkTyp !== headerTyp)) {
+    throw new TokenError(TokenError.codes.invalidType, 'Invalid typ.')
+  }
 
   // Verify the payload
   const now = (clockTimestamp || Date.now()) + clockTolerance
@@ -202,6 +208,7 @@ function verify(
     allowedAlgorithms,
     complete,
     cacheTTL,
+    checkTyp,
     clockTimestamp,
     clockTolerance,
     ignoreExpiration,
@@ -259,7 +266,7 @@ function verify(
 
   const { header, payload, signature } = decoded
   cacheContext.payload = payload
-  const validationContext = { validators, allowedAlgorithms, clockTimestamp, clockTolerance }
+  const validationContext = { validators, allowedAlgorithms, checkTyp, clockTimestamp, clockTolerance }
 
   // We have the key
   if (!callback) {
@@ -324,6 +331,7 @@ module.exports = function createVerifier(options) {
     complete,
     cache: cacheSize,
     cacheTTL,
+    checkTyp,
     clockTimestamp,
     clockTolerance,
     ignoreExpiration,
@@ -411,11 +419,17 @@ module.exports = function createVerifier(options) {
     validators.push({ type: 'string', claim: 'nonce', allowed: ensureStringClaimMatcher(allowedNonce) })
   }
 
+  let normalizedTyp = null
+  if (checkTyp) {
+    normalizedTyp = checkTyp.toLowerCase().replace(/^application\//, '')
+  }
+
   const context = {
     key,
     allowedAlgorithms,
     complete,
     cacheTTL,
+    checkTyp: normalizedTyp,
     clockTimestamp,
     clockTolerance,
     ignoreExpiration,

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -6,7 +6,7 @@ const { createDecoder } = require('../src')
 
 const defaultDecoder = createDecoder()
 // const rawDecoder = createDecoder({ json: false })
-const typDecoder = createDecoder({ skipTypCheck: true })
+const typDecoder = createDecoder({ checkTyp: 'JWT' })
 const completeDecoder = createDecoder({ complete: true })
 
 const token =
@@ -55,13 +55,7 @@ test('invalid header', t => {
 
   t.throws(() => defaultDecoder('Zm9v.b.c'), { message: 'The token header is not a valid base64url serialized JSON.' })
 
-  t.throws(() => defaultDecoder(nonJwtToken), { message: 'The type must be JWT.' })
-
-  t.end()
-})
-
-test('bypass aws cognito invalid header', t => {
-  t.doesNotThrow(() => typDecoder(nonJwtToken))
+  t.throws(() => typDecoder(nonJwtToken), { message: 'The type must be "JWT".' })
 
   t.end()
 })

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -6,6 +6,7 @@ const { createDecoder } = require('../src')
 
 const defaultDecoder = createDecoder()
 // const rawDecoder = createDecoder({ json: false })
+const typDecoder = createDecoder({ skipTypCheck: true })
 const completeDecoder = createDecoder({ complete: true })
 
 const token =
@@ -55,6 +56,12 @@ test('invalid header', t => {
   t.throws(() => defaultDecoder('Zm9v.b.c'), { message: 'The token header is not a valid base64url serialized JSON.' })
 
   t.throws(() => defaultDecoder(nonJwtToken), { message: 'The type must be JWT.' })
+
+  t.end()
+})
+
+test('bypass aws cognito invalid header', t => {
+  t.doesNotThrow(() => typDecoder(nonJwtToken))
 
   t.end()
 })

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -53,11 +53,13 @@ test('it correctly verifies a token - sync', t => {
     { a: 1, iat: 2000000000, exp: 2100000000 }
   )
 
-  t.throws(() => {
-    verify('eyJhbGciOiJIUzI1NiJ9.MTIz.UqiZ2LDYZqYB3xJgkHaihGQnJ_WPTz3hERDpA7bWYjA', { noTimestamp: true })
-  }, {
-    code: 'FAST_JWT_INVALID_TYPE'
-  })
+  t.strictDeepEqual(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      checkTyp: 'test',
+      noTimestamp: true
+    }),
+    { a: 1 }
+  )
 
   t.strictDeepEqual(
     verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -55,10 +55,28 @@ test('it correctly verifies a token - sync', t => {
 
   t.strictDeepEqual(
     verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
-      checkTyp: 'test',
+      checkTyp: 'jwt',
       noTimestamp: true
     }),
     { a: 1 }
+  )
+
+  t.strictDeepEqual(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6ImFwcGxpY2F0aW9uL2p3dCJ9.eyJhIjoxfQ.1ptuaNj5R0owE-5663LpMknK3eRgZVDHkMkOKkxlteM', {
+      checkTyp: 'jwt'
+    }),
+    { a: 1 }
+  )
+
+  t.throws(
+    () =>
+      verify(
+        'eyJhbGciOiJIUzI1NiJ9.eyJhIjoxfQ.LrlPmSL4FxrzAHJSYbKzsA997COXdYCeFKlt3zt5DIY',
+        { checkTyp: 'test' }
+      ),
+    {
+      message: 'Invalid typ.'
+    }
   )
 
   t.strictDeepEqual(


### PR DESCRIPTION
This change makes it possible to skip the `typ` check on the decoded header.
According to the JWT specs, a header with typ JWT is always expected, but in case of AWS Cognito, this property is not available. `skipTypCheck` on the decoder works around this.