### PR TITLE
feat: Add support for exp claim in the payload

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -77,6 +77,10 @@ function sign(
     throw new TokenError(TokenError.codes.invalidType, 'The payload must be an object.')
   }
 
+  if (payload.exp && (!Number.isInteger(payload.exp) || payload.exp < 0)) {
+    throw new TokenError(TokenError.codes.invalidClaimValue, 'The exp claim must be a positive integer.')
+  }
+
   // Prepare the header
   const header = {
     alg: algorithm,
@@ -95,7 +99,7 @@ function sign(
     ...payload,
     ...fixedPayload,
     iat: noTimestamp ? undefined : Math.floor(iat / 1000),
-    exp: expiresIn ? Math.floor((iat + expiresIn) / 1000) : undefined,
+    exp: expiresIn ? Math.floor((iat + expiresIn) / 1000) : payload.exp || undefined,
     nbf: notBefore ? Math.floor((iat + notBefore) / 1000) : undefined
   }
 

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -195,6 +195,34 @@ test('it adds a exp claim, overriding the payload one, only if the payload is a 
   t.end()
 })
 
+test('it adds the payload exp claim', t => {
+  t.equal(
+    sign({ a: 1, iat: 100, exp: 200 }, {}),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoyMDB9.RJbB3-VIjLIQr-VmZ1Kl42MrHr2pAU-CQuXK8jHMKR0'
+  )
+
+  t.end()
+})
+
+test('it ignores invalid exp claim', t => {
+  t.equal(
+    sign({ a: 1, iat: 100, exp: Number.NaN }, {}),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMH0.5V5yFNSqmn0w6yDR1vUbykF36WwdQmADMTLJwiJtx8w'
+  )
+
+  t.equal(
+    sign({ a: 1, iat: 100, exp: null }, {}),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMH0.5V5yFNSqmn0w6yDR1vUbykF36WwdQmADMTLJwiJtx8w'
+  )
+
+  t.equal(
+    sign({ a: 1, iat: 100, exp: undefined }, {}),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMH0.5V5yFNSqmn0w6yDR1vUbykF36WwdQmADMTLJwiJtx8w'
+  )
+
+  t.end()
+})
+
 test('it adds a nbf claim, overriding the payload one, only if the payload is a object', t => {
   t.equal(
     sign({ a: 1, iat: 100 }, { notBefore: 1000 }),
@@ -423,6 +451,18 @@ test('payload validation', t => {
 
   t.rejects(async () => createSigner({ key: () => 'secret' })(123), {
     message: 'The payload must be an object.'
+  })
+
+  t.end()
+})
+
+test('exp claim validation', t => {
+  t.throws(() => createSigner({ key: 'secret' })({ exp: 'exp' }), {
+    message: 'The exp claim must be a positive integer.'
+  })
+
+  t.throws(() => createSigner({ key: 'secret' })({ exp: -1 }), {
+    message: 'The exp claim must be a positive integer.'
   })
 
   t.end()


### PR DESCRIPTION
Add support for a custom exp claim in the payload (Issue #58)
```javascript
const signSync = createSigner({ key: 'secret' })
const token = signSync({
  a: 1,
  exp: Math.floor(Date.now() / 1000) + (60 * 60 * 2),
})
```

I kept the behavior of overwriting "exp" if the option "expiresIn" is set.
Should I add any more validations or tests, or change some behavior?

Thanks