### PR TITLE
fix: Fixed allowed claims verification.

### DIFF
--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -479,7 +479,7 @@ test('it validates the aud claim only if explicitily enabled', t => {
         { allowedAud: 'AUD2' }
       )
     },
-    { message: 'None of aud claim values is allowed.' }
+    { message: 'None of aud claim values are allowed.' }
   )
 
   t.throws(
@@ -489,18 +489,18 @@ test('it validates the aud claim only if explicitily enabled', t => {
         { allowedAud: [/abc/, 'cde'] }
       )
     },
-    { message: 'None of aud claim values is allowed.' }
+    { message: 'None of aud claim values are allowed.' }
   )
 
   t.strictDeepEqual(
     verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEIiwiRFVBMiJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.lhu5t694BY0QmF7SChUw7Z9nUPtupWCkhrQ2rqN06GU',
       { allowedAud: 'AUD' }
     ),
     {
       a: 1,
       jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
+      aud: ['AUD', 'DUA2'],
       iss: 'ISS',
       sub: 'SUB',
       nonce: 'NONCE'
@@ -772,6 +772,32 @@ test('it validates the nonce claim only if explicitily enabled', t => {
       sub: 'SUB',
       nonce: 'NONCE'
     }
+  )
+
+  t.end()
+})
+
+test('it validates allowed claims values using equality when appropriate', t => {
+  // The iss claim in the token starts with ISS
+  t.throws(
+    () => {
+      return verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpc3MiOiJJU1NfUFJFRklYIn0.yAVrfuzH-1H_dzd8YhDV2ukWAGHB4DY4Wiv1cqz1JaY',
+        { allowedIss: 'ISS' }
+      )
+    },
+    { message: 'The iss claim value is not allowed.' }
+  )
+
+  // The iss claim in the token ends with ISS
+  t.throws(
+    () => {
+      return verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpc3MiOiJTVUZGSVhfSVNTIn0.YNfIVGQCnIk0sQzsvOnLl_ueRs64m2M2BgiKyczzsAk',
+        { allowedIss: 'ISS' }
+      )
+    },
+    { message: 'The iss claim value is not allowed.' }
   )
 
   t.end()


### PR DESCRIPTION
This PR fixes a bug where allow `allowed*` options in the `createVerifier` were mistakenly converted to Regexp when specified as strings.

This leads to accept a claim that just contained the allowed ones. For instance:

```javascript
const { createSigner } = require('fast-jwt')
const { createVerifier } = require('fast-jwt')

const signSync = createSigner({ key: 'secret' })
const verifySync = createVerifier({ key: 'secret', allowedIss: 'ISS' })

// The following should throw, but it currently does not
const payload = verifySync(signSync({iss: 'FOO_ISS_BAR`}))
```

The solution is to use equality check rather than regexp testing.