### PR TITLE
chore: add files field to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-benchmarks

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "main": "src/index.js",
   "typings": "src/index.d.ts",
   "types": "src/index.d.ts",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "prepublishOnly": "npm run ci",
     "postpublish": "git push origin && git push origin -f --tags",


### PR DESCRIPTION
PR https://github.com/nearform/fast-jwt/pull/69 inadvertently caused coverage files to be included in the published package.  This PR adds `test`, `nyc_output`, and `coverage` directories to `.npmignore` in order to fix it.