### PR TITLE
Add github action release-notify 

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,15 @@
+name: notify-release
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    - cron: '30 8 * * *'
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify release
+        uses: nearform/github-action-notify-release@v1.2.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding CI step to check on a daily basis if there are any commits older than 7 days that have not been released yet.