### PR TITLE
refactor (docs): fix `mutatePayload` definition sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Create a signer function by calling `createSigner` and providing one or more of 
 
 - `key`: A string or a buffer containing the secret for `HS*` algorithms, the PEM encoded public key for `RS*`, `PS*`, `ES*` and `EdDSA` algorithms or it can be an object containing passphrase protected private key (more details below). The key can also be a function accepting a Node style callback or a function returning a promise. This is the only mandatory option, which must NOT be provided if the token algorithm is `none`.
 - `algorithm`: The algorithm to use to sign the token. The default is autodetected from the key, using `RS256` for RSA private keys, `HS256` for plain secrets and the correspondent `ES` or `EdDSA` algorithms for EC or Ed\* private keys.
-- `mutatePayload`: If the original payload must be modified in place (via `Object.assign`) and thus will result changed to the caller funciton.
+- `mutatePayload`: If set to `true`, the original payload will be modified in place (via `Object.assign`) by the signing function. This is useful if you need a raw reference to the payload after claims have been applied to it but before it has been encoded into a token.
 - `expiresIn`: Time span (in milliseconds) after which the token expires, added as the `exp` claim in the payload. This will override any existing value in the claim.
 - `notBefore`: Time span (in milliseconds) before the token is active, added as the `nbf` claim in the payload. This will override any existing value in the claim.
 - `jti`: The token id, added as the `jti` claim in the payload. This will override any existing value in the claim.


### PR DESCRIPTION
Hello.

Update the `mutatePayload` related documentation.