### PR TITLE
Refactoring checkAreCompatibleAlgorithms function 

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -22,7 +22,7 @@ function checkAreCompatibleAlgorithms(expected, actual) {
 
     // if at least one of the expected algorithms is compatible we're done
     if (valid) {
-      break;
+      break
     }
   }
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -15,17 +15,15 @@ function exactStringClaimMatcher(allowed, actual) {
 }
 
 function checkAreCompatibleAlgorithms(expected, actual) {
-  const expectedType = expected[0].slice(0, 2)
-  const actualType = actual[0].slice(0, 2)
+  let valid = false
 
-  let valid = true // We accept everything for HS
+  for (const expectedAlg of expected) {
+    valid = actual.indexOf(expectedAlg) !== -1
 
-  if (expectedType === 'RS' || expectedType === 'PS') {
-    // RS and PS use same keys
-    valid = actualType === 'RS'
-  } else if (expectedType === 'ES' || expectedType === 'Ed') {
-    // ES and Ed only can have a single value
-    valid = expectedType === actualType
+    // if at least one of the expected algorithms is compatible we're done
+    if (valid) {
+      break;
+    }
   }
 
   if (!valid) {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -287,7 +287,7 @@ test('it handles decoding errors', async t => {
   })
 })
 
-test('it validates if the token is using an allowed algorithm - sync ', t => {
+test('it validates if the token is not using an allowed algorithm - sync ', t => {
   t.throws(
     () => {
       return verify(
@@ -301,7 +301,51 @@ test('it validates if the token is using an allowed algorithm - sync ', t => {
   t.end()
 })
 
-test('it validates if the public is consistent with the allowed algorithms - sync ', t => {
+test('it validates if the token is using one of the allowed algorithm - sync ', t => {
+  t.strictSame(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      noTimestamp: true
+    }),
+    { a: 1 }
+  )
+
+  t.strictSame(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      noTimestamp: true,
+      algorithms: ['HS256']
+    }),
+    { a: 1 }
+  )
+
+  t.strictSame(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      noTimestamp: true,
+      algorithms: ['RS256', 'HS256']
+    }),
+    { a: 1 }
+  )
+
+  t.strictSame(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      noTimestamp: true,
+      algorithms: ['RS256', 'HS256'],
+      key: 'secret'
+    }),
+    { a: 1 }
+  )
+
+  t.strictSame(
+    verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
+      noTimestamp: true,
+      algorithms: ['RS256', 'RS384', 'RS512', 'HS256', 'HS384', 'HS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512', 'EdDSA']
+    }),
+    { a: 1 }
+  )
+
+  t.end()
+})
+
+test('it validates if the public key is consistent with the allowed algorithms - sync ', t => {
   t.throws(
     () => {
       return verify(


### PR DESCRIPTION
Refactored `checkAreCompatibleAlgorithms` function  to take into account all of the algorithms supplied in the options as allowed algorithms.
Closes #157 