### PR TITLE
Feat/add pkgjs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
-    - uses: pkgjs/action/.github/workflows/node-test.yaml@main
+    uses: pkgjs/action/.github/workflows/node-test.yaml@main
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  test:
+  build:
     uses: pkgjs/action/.github/workflows/node-test.yaml@main
 
   automerge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    uses: pkgjs/action/.github/workflows/node-test.yaml@main
+    uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1.1
     with:
       strategy-fail-fast: true
       test-command: npm run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ jobs:
   build:
     uses: pkgjs/action/.github/workflows/node-test.yaml@main
     with:
-      post-install-steps: 'npm run lint'
+      strategy-fail-fast: true
+      test-command: npm run ci
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   build:
     uses: pkgjs/action/.github/workflows/node-test.yaml@main
+    with:
+      post-install-steps: 'npm run lint'
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: pkgjs/action/.github/workflows/node-test.yaml@main
+  test:
+    - uses: pkgjs/action/.github/workflows/node-test.yaml@main
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12, 14, 16, 17]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.4.0
-      - name: Use Node.js
-        uses: actions/setup-node@v2.5.0
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Restore cached dependencies
-        uses: actions/cache@v2.1.7
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('package.json') }}
-      - name: Install dependencies
-        run: npm install
-      - name: Run Tests
-        run: npm run ci
+    test:
+      uses: pkgjs/action/.github/workflows/node-test.yaml@main
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    test:
-      uses: pkgjs/action/.github/workflows/node-test.yaml@main
+    steps:
+      - uses: pkgjs/action/.github/workflows/node-test.yaml@main
 
   automerge:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1.1
     with:
       strategy-fail-fast: true
-      test-command: npm run ci
+      test-command: npm run test:ci
 
   automerge:
     needs: build

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^4.0.3"
   },
   "engines": {
-    "node": ">= 10.12.0"
+    "node": "^17 || ^16 || ^14 || ^12"
   },
   "tsd": {
     "directory": "test"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^4.0.3"
   },
   "engines": {
-    "node": "^17 || ^16 || ^14 || ^12"
+    "node": "^16 || ^14 || ^12"
   },
   "tsd": {
     "directory": "test"


### PR DESCRIPTION
I've updated the `ci` workflow to use https://github.com/pkgjs/action.
~Few notes:~
~- the action is not released yet and thus it's using the `@main` version~
~- the "link" to the action is `pkgjs/action/.github/workflows/node-test.yaml@main` which is a bit unusual (this one directly references the `yaml` file) compared to other actions for example: `fastify/github-action-merge-dependabot@v2.7.1`~

~Other than these two notes I think it's working good.~
Update: As @simoneb pointed out, this is a reusable workflow and the reference is correct (https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow)

Closes #204 
