### PR TITLE
Distinguish between sync & async methods in types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,11 +47,13 @@ type KeyFetcher =
   | ((header: { [key: string]: any }) => Promise<string | Buffer>)
   | ((header: { [key: string]: any }, cb: (err: Error | TokenError | null, key: string | Buffer) => void) => void)
 
-declare function Signer(payload: string | Buffer | { [key: string]: any }): Promise<string>
-declare function Signer(payload: string | Buffer | { [key: string]: any }, cb: SignerCallback): void
+declare function SignerSync(payload: string | Buffer | { [key: string]: any }): string
+declare function SignerAsync(payload: string | Buffer | { [key: string]: any }): Promise<string>
+declare function SignerAsync(payload: string | Buffer | { [key: string]: any }, cb: SignerCallback): void
 
-declare function Verifier(token: string | Buffer): Promise<any>
-declare function Verifier(token: string | Buffer, cb: object): void
+declare function VerifierSync(token: string | Buffer): any
+declare function VerifierAsync(token: string | Buffer): Promise<any>
+declare function VerifierAsync(token: string | Buffer, cb: object): void
 
 export interface JwtHeader {
   alg: string | Algorithm
@@ -67,7 +69,6 @@ export interface JwtHeader {
 }
 
 export interface SignerOptions {
-  key: string | Buffer | KeyFetcher
   algorithm: Algorithm
   mutatePayload: boolean
   expiresIn: number
@@ -89,7 +90,6 @@ export interface DecoderOptions {
 }
 
 export interface VerifierOptions {
-  key: string | Buffer | KeyFetcher
   algorithms: Algorithm[]
   complete: boolean
   cache: boolean | number
@@ -106,6 +106,8 @@ export interface VerifierOptions {
   clockTolerance: number
 }
 
-export function createSigner(options?: Partial<SignerOptions>): typeof Signer
+export function createSigner(options?: Partial<SignerOptions & { key: string | Buffer }>): typeof SignerSync
+export function createSigner(options?: Partial<SignerOptions & { key: KeyFetcher }>): typeof SignerAsync
 export function createDecoder(options?: Partial<DecoderOptions>): (token: string | Buffer) => any
-export function createVerifier(options?: Partial<VerifierOptions>): typeof Verifier
+export function createVerifier(options?: Partial<VerifierOptions & { key: string | Buffer }>): typeof VerifierSync
+export function createVerifier(options?: Partial<VerifierOptions & { key: KeyFetcher }>): typeof VerifierAsync

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -5,9 +5,12 @@ import { expectAssignable, expectNotAssignable } from 'tsd'
 
 // Signing
 // Buffer key, both async/callback styles
-const signer = createSigner({ key: Buffer.from('KEY'), algorithm: 'RS256' })
-signer({ key: '1' }).then(console.log, console.log)
-signer({ key: '1' }, (_e: Error | null, _token?: string) => {})
+const signerSync = createSigner({ key: Buffer.from('KEY'), algorithm: 'RS256' })
+signerSync({ key: '1' })
+
+const signerAsync = createSigner({ key: () => Buffer.from('KEY'), algorithm: 'RS256' })
+signerAsync({ key: '1' }).then(console.log, console.log)
+signerAsync({ key: '1' }, (_e: Error | null, _token?: string) => {})
 
 // Dynamic key in callback style
 createSigner({
@@ -32,9 +35,12 @@ decoder(Buffer.from('FOO'))
 
 // Verifying
 // String key, both async/callback styles
-const verifier = createVerifier({ key: 'KEY', algorithms: ['RS256'] })
-verifier('123').then(console.log, console.log)
-verifier(Buffer.from('456'), (_e: Error | null, _token?: string) => {})
+const verifierSync = createVerifier({ key: 'KEY', algorithms: ['RS256'] })
+verifierSync('2134')
+
+const verifierAsync = createVerifier({ key: () => 'KEY', algorithms: ['RS256'] })
+verifierAsync('123').then(console.log, console.log)
+verifierAsync(Buffer.from('456'), (_e: Error | null, _token?: string) => {})
 
 // Dynamic key in callback style
 createVerifier({


### PR DESCRIPTION
Right now types define Signer and Verifier as either Promise or a
callback function; however looking at the examples in README and
code [0], this is true only if `key` is a function.

So changing the types a bit here to reflect reality.

[0] https://github.com/nearform/fast-jwt/blob/c239279dfe6a086a68132b05a5c729fe11352602/src/signer.js#L303
