### PR TITLE
Introduce `requiredClaims` option to the verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Create a verifier function by calling `createVerifier` and providing one or more
 
 - `allowedNonce`: A string, a regular expression, an array of strings or an array of regular expressions containing allowed values for the nonce claim (`nonce`). By default, all values are accepted.
 
+- `requiredClaims`: An array of strings containing which claims should exist in the token. By default, no claim is marked as required.
+
 - `ignoreExpiration`: Do not validate the expiration of the token. Default is `false`.
 
 - `ignoreNotBefore`: Do not validate the activation of the token. Default is `false`.

--- a/src/error.js
+++ b/src/error.js
@@ -30,7 +30,8 @@ TokenError.codes = {
   missingKey: 'FAST_JWT_MISSING_KEY',
   keyFetchingError: 'FAST_JWT_KEY_FETCHING_ERROR',
   signError: 'FAST_JWT_SIGN_ERROR',
-  verifyError: 'FAST_JWT_VERIFY_ERROR'
+  verifyError: 'FAST_JWT_VERIFY_ERROR',
+  missingRequiredClaim: 'FAST_JWT_MISSING_REQUIRED_CLAIM'
 }
 
 TokenError.wrap = function(originalError, code, message) {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -873,6 +873,46 @@ test('it validates allowed claims values using equality when appropriate', t => 
   t.end()
 })
 
+test('it validates whether a required claim is present in the payload or not', t => {
+  // Token payload: { "iss": "ISS"}
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJJU1MifQ.FKjJd2A-T8ufN7Y0LpjMR23P7CwEQ3Y-LBIYd2Vh_Rs'
+
+  t.strictSame(
+    verify(
+      token,
+      { allowedIss: 'ISS', requiredClaims: ['iss'] }
+    ),
+    { iss: 'ISS' }
+  )
+
+  t.throws(
+    () => {
+      return verify(
+        token,
+        { allowedSub: 'SUB', requiredClaims: ['sub'] }
+      )
+    },
+    { message: 'The sub claim is required.' }
+  )
+
+  t.end()
+})
+
+test('it skips validation when an allowed claim isn\'t present in the payload', t => {
+  // Token payload: { "iss": "ISS"}
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJJU1MifQ.FKjJd2A-T8ufN7Y0LpjMR23P7CwEQ3Y-LBIYd2Vh_Rs'
+
+  t.strictSame(
+    verify(
+      token,
+      { allowedIss: 'ISS', allowedAud: 'AUD' }
+    ),
+    { iss: 'ISS' }
+  )
+
+  t.end()
+})
+
 test('token type validation', t => {
   t.throws(() => createVerifier({ key: 'secret' })(123), {
     message: 'The token must be a string or a buffer.'
@@ -920,6 +960,14 @@ test('options validation - cacheTTL', t => {
 
   t.throws(() => createVerifier({ key: 'secret', cacheTTL: -1 }), {
     message: 'The cacheTTL option must be a positive number.'
+  })
+
+  t.end()
+})
+
+test('options validation - requiredClaims', t => {
+  t.throws(() => createVerifier({ key: 'secret', requiredClaims: 'ISS' }), {
+    message: 'The requiredClaims option must be an array.'
   })
 
   t.end()


### PR DESCRIPTION
Introduces a new option, `requiredClaims`, to the verifier, which will check in the token for the presence of a set of claims.
Note that no claim is required by default, this way preserving the current behavior of skipping undefined claims even when an `allowed*` option is used.

Closes #182 