### PR TITLE
fix benchmarks

### DIFF
--- a/benchmarks/auth0.mjs
+++ b/benchmarks/auth0.mjs
@@ -1,7 +1,15 @@
 'use strict'
 
-const { isMainThread } = require('worker_threads')
-const { tokens, privateKeys, publicKeys, compareSigning, compareVerifying, saveLogs } = require('./utils')
+import { isMainThread } from 'worker_threads'
+
+import {
+  tokens,
+  privateKeys,
+  publicKeys,
+  compareSigning,
+  compareVerifying,
+  saveLogs
+} from './utils.mjs'
 
 async function runSuites() {
   if (!isMainThread) {

--- a/benchmarks/decode.mjs
+++ b/benchmarks/decode.mjs
@@ -1,6 +1,9 @@
 'use strict'
 
-const { compareDecoding, saveLogs } = require('./utils')
+import {
+  compareDecoding,
+  saveLogs
+} from './utils.mjs'
 
 // Regenerate this token after regenerating the keys by running `npm run generate-tokens` and getting the RS512 token
 const rsToken =

--- a/benchmarks/sign.mjs
+++ b/benchmarks/sign.mjs
@@ -1,7 +1,12 @@
 'use strict'
 
-const { isMainThread } = require('worker_threads')
-const { privateKeys, publicKeys, compareSigning, saveLogs } = require('./utils')
+import { isMainThread } from 'worker_threads'
+import {
+  privateKeys,
+  publicKeys,
+  compareSigning,
+  saveLogs
+} from './utils.mjs'
 
 async function runSuites() {
   if (!isMainThread) {

--- a/benchmarks/utils.mjs
+++ b/benchmarks/utils.mjs
@@ -1,17 +1,34 @@
 'use strict'
 
-const cronometro = require('cronometro')
-const { readFileSync } = require('fs')
-const { mkdir, writeFile } = require('fs').promises
-const { resolve } = require('path')
+import cronometro from 'cronometro'
+import { readFileSync } from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
-const { sign: jsonwebtokenSign, decode: jsonwebtokenDecode, verify: jsonwebtokenVerify } = require('jsonwebtoken')
+import jwt from 'jsonwebtoken'
+
+import {
+  JWT as JWTJose,
+  JWK as JWKJose
+} from 'jose'
+
+import {
+  createSigner,
+  createDecoder,
+  createVerifier
+} from '../src/index.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
 const {
-  JWT: { sign: joseSign, verify: joseVerify, decode: joseDecode },
-  JWK: { asKey }
-} = require('jose')
+  sign: jsonwebtokenSign,
+  decode: jsonwebtokenDecode,
+  verify: jsonwebtokenVerify
+} = jwt
 
-const { createSigner, createDecoder, createVerifier } = require('../src')
+const { sign: joseSign, verify: joseVerify, decode: joseDecode } = JWTJose
+const { asKey } = JWKJose
 
 const output = []
 const cronometroOptions = {
@@ -20,7 +37,7 @@ const cronometroOptions = {
   print: { compare: true, compareMode: 'base' }
 }
 
-const tokens = {
+export const tokens = {
   /*
     Regenerate these tokens after regenerating the keys
     by running `npm run test:generate-tokens` and getting the HS256, RS256, HS512, ES512, RS512, PS512 and EdDSA tokens
@@ -41,7 +58,7 @@ const tokens = {
     'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJraWQiOiIxMjMifQ.eyJhIjoxLCJiIjoyLCJjIjozLCJpYXQiOjE1ODY3ODQ3ODF9.PDIxWOWhAHr-7Zy7UC8W4pRuk7dMYTD8xy0DR0N102P0pXK6U4r6THHe66muTdSM3qiDHZnync1WQp-10QFLCQ'
 }
 
-const privateKeys = {
+export const privateKeys = {
   HS256: 'secretsecretsecret',
   RS256: readFileSync(resolve(__dirname, './keys/rs-512-private.key')),
   HS512: 'secretsecretsecret',
@@ -51,7 +68,7 @@ const privateKeys = {
   EdDSA: readFileSync(resolve(__dirname, './keys/ed-25519-private.key'))
 }
 
-const publicKeys = {
+export const publicKeys = {
   HS256: 'secretsecretsecret',
   RS256: readFileSync(resolve(__dirname, './keys/rs-512-public.key')),
   HS512: 'secretsecretsecret',
@@ -61,7 +78,7 @@ const publicKeys = {
   EdDSA: readFileSync(resolve(__dirname, './keys/ed-25519-public.key'))
 }
 
-async function saveLogs(type) {
+export async function saveLogs(type) {
   const now = new Date()
     .toISOString()
     .replace(/[-:]/g, '')
@@ -84,7 +101,7 @@ function log(message) {
   output.push(message)
 }
 
-function compareDecoding(token, algorithm) {
+export function compareDecoding(token, algorithm) {
   const fastjwtDecoder = createDecoder()
   const fastjwtCompleteDecoder = createDecoder({ complete: true })
 
@@ -122,7 +139,7 @@ function compareDecoding(token, algorithm) {
   )
 }
 
-async function compareSigning(payload, algorithm, privateKey, publicKey) {
+export async function compareSigning(payload, algorithm, privateKey, publicKey) {
   const isEdDSA = algorithm.slice(0, 2) === 'Ed'
 
   const fastjwtSign = createSigner({ algorithm, key: privateKey, noTimestamp: true })
@@ -190,7 +207,7 @@ async function compareSigning(payload, algorithm, privateKey, publicKey) {
   return cronometro(tests, cronometroOptions)
 }
 
-function compareVerifying(token, algorithm, publicKey) {
+export function compareVerifying(token, algorithm, publicKey) {
   const isEdDSA = algorithm.slice(0, 2) === 'Ed'
 
   const fastjwtVerify = createVerifier({ key: publicKey })
@@ -241,14 +258,4 @@ function compareVerifying(token, algorithm, publicKey) {
   }
 
   return cronometro(tests, cronometroOptions)
-}
-
-module.exports = {
-  tokens,
-  privateKeys,
-  publicKeys,
-  compareDecoding,
-  compareSigning,
-  compareVerifying,
-  saveLogs
 }

--- a/benchmarks/verify.mjs
+++ b/benchmarks/verify.mjs
@@ -1,7 +1,12 @@
 'use strict'
 
-const { isMainThread } = require('worker_threads')
-const { tokens, publicKeys, compareVerifying, saveLogs } = require('./utils')
+import { isMainThread } from 'worker_threads'
+import {
+  tokens,
+  publicKeys,
+  compareVerifying,
+  saveLogs
+} from './utils.mjs'
 
 async function runSuites() {
   if (!isMainThread) {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "test:watch": "tap --watch --reporter=spec --coverage-report=html --coverage-report=text --no-browser test/*.spec.js test/**/*.spec.js",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",
     "test:generate-tokens": "node benchmarks/keys/generate-tokens.js",
-    "benchmark:sign": "node benchmarks/sign.js",
-    "benchmark:decode": "node benchmarks/decode.js",
-    "benchmark:verify": "node benchmarks/verify.js",
-    "benchmark:auth0": "node benchmarks/auth0.js"
+    "benchmark:sign": "node benchmarks/sign.mjs",
+    "benchmark:decode": "node benchmarks/decode.mjs",
+    "benchmark:verify": "node benchmarks/verify.mjs",
+    "benchmark:auth0": "node benchmarks/auth0.mjs"
   },
   "dependencies": {
     "asn1.js": "^5.3.0",


### PR DESCRIPTION
This PR converts the benchmark CommonJS modules into ES modules so we can use `cronometro` properly.
Closes #185 