### PR TITLE
fix: clockTolerance property in verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Create a verifier function by calling `createVerifier` and providing one or more
 
 - `clockTimestamp`: The timestamp in milliseconds (like the output of `Date.now()`) that should be used as the current time for all necessary time comparisons. Default is the system time.
 
-- `clockTolerance`: Timespan in milliseconds to add the current timestamp when performing time comparisons. Default is `0`.
+- `clockTolerance`: Timespan in milliseconds is the tolerance to apply to the current timestamp when performing time comparisons. Default is `0`.
 
 The verifier is a function which accepts a token (as Buffer or string) and returns the payload or the sections of the token.
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -189,7 +189,7 @@ function verifyToken(
   }
 
   // Verify the payload
-  const now = (clockTimestamp || Date.now()) + clockTolerance
+  const now = clockTimestamp || Date.now()
 
   for (const validator of validators) {
     const { type, claim, allowed, array, modifier, greater, errorCode, errorVerb } = validator
@@ -393,7 +393,7 @@ module.exports = function createVerifier(options) {
 
   if (clockTolerance && (typeof clockTolerance !== 'number' || clockTolerance < 0)) {
     throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a positive number.')
-  } else {
+  } else if (!clockTolerance) {
     clockTolerance = 0
   }
 
@@ -409,11 +409,11 @@ module.exports = function createVerifier(options) {
   const validators = []
 
   if (!ignoreNotBefore) {
-    validators.push({ type: 'date', claim: 'nbf', errorCode: 'inactive', errorVerb: 'will be active', greater: true })
+    validators.push({ type: 'date', claim: 'nbf', errorCode: 'inactive', errorVerb: 'will be active', greater: true, modifier: -clockTolerance })
   }
 
   if (!ignoreExpiration) {
-    validators.push({ type: 'date', claim: 'exp', errorCode: 'expired', errorVerb: 'has expired' })
+    validators.push({ type: 'date', claim: 'exp', errorCode: 'expired', errorVerb: 'has expired', modifier: +clockTolerance })
   }
 
   if (typeof maxAge === 'number') {

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -82,13 +82,13 @@ function cacheSet(
 
   // Add time range of the token
   if (hasIat) {
-    cacheValue[1] = !ignoreNotBefore && typeof payload.nbf === 'number' ? payload.nbf * 1000 : 0
+    cacheValue[1] = !ignoreNotBefore && typeof payload.nbf === 'number' ? (payload.nbf * 1000 - clockTolerance) : 0
 
     if (!ignoreExpiration) {
       if (typeof payload.exp === 'number') {
-        cacheValue[2] = payload.exp * 1000
+        cacheValue[2] = payload.exp * 1000 + clockTolerance
       } else if (maxAge) {
-        cacheValue[2] = payload.iat * 1000 + maxAge
+        cacheValue[2] = payload.iat * 1000 + maxAge + clockTolerance
       }
     }
   }
@@ -255,7 +255,7 @@ function verify(
   // Check the cache
   if (cache) {
     const [value, min, max] = cache.get(hashToken(token)) || [undefined, 0, 0]
-    const now = (clockTimestamp || Date.now()) + clockTolerance
+    const now = clockTimestamp || Date.now()
 
     // Validate time range
     if (typeof value !== 'undefined' && (min === 0 || now > min) && (max === 0 || now <= max)) {

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -359,7 +359,7 @@ module.exports = function createVerifier(options) {
     allowedSub,
     allowedNonce,
     requiredClaims
-  } = { cacheTTL: 600000, ...options }
+  } = { cacheTTL: 600000, clockTolerance: 0, ...options }
 
   // Validate options
   if (!Array.isArray(allowedAlgorithms)) {
@@ -393,8 +393,6 @@ module.exports = function createVerifier(options) {
 
   if (clockTolerance && (typeof clockTolerance !== 'number' || clockTolerance < 0)) {
     throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a positive number.')
-  } else if (!clockTolerance) {
-    clockTolerance = 0
   }
 
   if (cacheTTL && (typeof cacheTTL !== 'number' || cacheTTL < 0)) {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1314,7 +1314,7 @@ test('caching - should be able to consider clockTolerance on both nbf and exp fi
   t.equal(verifier.cache.size, 1)
   t.strictSame(verifier.cache.get(hashToken(token)), [{ a: 1, iat: 100, nbf: 300, exp: 500 }, 240000, 560000])
 
-  // Now advance again after the expiry time, in clockTolerance range (current time going to be 450000 )
+  // Now advance again after the expiry time, in clockTolerance range (current time going to be 540000 )
   clock.tick(150000)
   t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
   t.equal(verifier.cache.size, 1)

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -399,6 +399,27 @@ test('it validates if the token is active unless explicitily disabled', t => {
   t.end()
 })
 
+test('it validates if the token is active including the clock tolerance', t => {
+  const clockTimestamp = Date.now()
+  const notBefore = 1000
+  const token = createSigner({ key: 'secret', clockTimestamp, notBefore })({ a: 1 })
+
+  t.strictSame(
+    verify(
+      token,
+      {
+        clockTolerance: 5000
+      }
+    ),
+    {
+      a: 1,
+      iat: Math.floor(clockTimestamp / 1000),
+      nbf: Math.floor((clockTimestamp + notBefore) / 1000)
+    }
+  )
+  t.end()
+})
+
 test('it validates if the token has not expired (via exp) unless explicitily disabled', t => {
   t.throws(
     () => {
@@ -439,6 +460,27 @@ test('it validates if the token has not expired (via maxAge) only if explicitily
     { a: 1, iat: 100 }
   )
 
+  t.end()
+})
+
+test('it validates if the token has not expired including the clock tolerance', t => {
+  const clockTimestamp = Date.now() - 5000
+  const expiresIn = 1000
+  const token = createSigner({ key: 'secret', clockTimestamp, expiresIn })({ a: 1 })
+
+  t.strictSame(
+    verify(
+      token,
+      {
+        clockTolerance: 5000
+      }
+    ),
+    {
+      a: 1,
+      iat: Math.floor(clockTimestamp / 1000),
+      exp: Math.floor((clockTimestamp + expiresIn) / 1000)
+    }
+  )
   t.end()
 })
 

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1280,6 +1280,60 @@ test('caching - should be able to consider both nbf and exp field at the same ti
   t.end()
 })
 
+test('caching - should be able to consider clockTolerance on both nbf and exp field', t => {
+  const clock = fakeTime({ now: 100000 })
+
+  const signer = createSigner({ key: 'secret', expiresIn: 400000, notBefore: 200000 })
+  const verifier = createVerifier({ key: 'secret', cache: true, clockTolerance: 60000 })
+  const token = signer({ a: 1 })
+
+  // At the beginning, the token is not active yet
+  t.equal(verifier.cache.size, 0)
+  t.throws(() => verifier(token), { message: 'The token will be active at 1970-01-01T00:04:00.000Z.' })
+  t.equal(verifier.cache.size, 1)
+  t.throws(() => verifier(token), { message: 'The token will be active at 1970-01-01T00:04:00.000Z.' })
+  t.ok(verifier.cache.get(hashToken(token))[0] instanceof TokenError)
+
+  // Now advance before the activation time, in clockTolerance range
+  clock.tick(140000)
+
+  // The token should now be active and the cache should have been updated to reflect it
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier.cache.get(hashToken(token)), [{ a: 1, iat: 100, nbf: 300, exp: 500 }, 240000, 560000])
+
+  // Now advance to activation time
+  clock.tick(150000)
+
+  // The token should now be active and the cache should have been updated to reflect it
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier.cache.get(hashToken(token)), [{ a: 1, iat: 100, nbf: 300, exp: 500 }, 240000, 560000])
+
+  // Now advance again after the expiry time, in clockTolerance range (current time going to be 450000 )
+  clock.tick(150000)
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier(token), { a: 1, iat: 100, nbf: 300, exp: 500 })
+  t.equal(verifier.cache.size, 1)
+  t.strictSame(verifier.cache.get(hashToken(token)), [{ a: 1, iat: 100, nbf: 300, exp: 500 }, 240000, 560000])
+
+  clock.tick(100000)
+  // The token should now be expired and the cache should have been updated to reflect it
+  t.throws(() => verifier(token), { message: 'The token has expired at 1970-01-01T00:09:20.000Z.' })
+  t.equal(verifier.cache.size, 1)
+  t.ok(verifier.cache.get(hashToken(token))[0] instanceof TokenError)
+  t.throws(() => verifier(token), { message: 'The token has expired at 1970-01-01T00:09:20.000Z.' })
+  t.throws(() => verifier(token), { message: 'The token has expired at 1970-01-01T00:09:20.000Z.' })
+
+  clock.uninstall()
+  t.end()
+})
+
 test('caching - should ignore the nbf and exp when asked to', t => {
   const clock = fakeTime({ now: 100000 })
 


### PR DESCRIPTION
This should fix #192,

The `clockTolerance` property in `createVerifier` options will now be tolerant on both `nbf`  and `exp` token properties.

The modification should keep the exact same behavior with `maxAge` and `cacheTTL`.