### PR TITLE
Fix cache containing "not yet active tokens"  that never become active 

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -259,7 +259,7 @@ function verify(
 
     // Validate time range
     if (typeof value !== 'undefined' &&
-      (min === 0 || (now < min && value.code === 'FAST_JWT_INACTIVE') || (now > min && value.code !== 'FAST_JWT_INACTIVE')) &&
+      (min === 0 || (now < min && value.code === 'FAST_JWT_INACTIVE') || (now >= min && value.code !== 'FAST_JWT_INACTIVE')) &&
       (max === 0 || now <= max)) {
       // Cache hit
       return handleCachedResult(value, callback, promise)

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -258,7 +258,9 @@ function verify(
     const now = (clockTimestamp || Date.now()) + clockTolerance
 
     // Validate time range
-    if (typeof value !== 'undefined' && (min === 0 || now > min) && (max === 0 || now <= max)) {
+    if (typeof value !== 'undefined' &&
+      (min === 0 || (now < min && value.code === 'FAST_JWT_INACTIVE') || (now > min && value.code !== 'FAST_JWT_INACTIVE')) &&
+      (max === 0 || now <= max)) {
       // Cache hit
       return handleCachedResult(value, callback, promise)
     }


### PR DESCRIPTION
Fix #194 

I tried to fix the behavior without changing too much lines, but the result isn't that easy to read.
Also I'm not sure if using the `FAST_JWT_INACTIVE` code here is the way to go...