### PR TITLE
Feat/add notify twitter workflow

### DIFF
--- a/.github/workflows/notify-twitter.yml
+++ b/.github/workflows/notify-twitter.yml
@@ -1,4 +1,4 @@
-name: Notify twitter
+name: Notify Twitter
 
 on:
   workflow_dispatch:

--- a/.github/workflows/notify-twitter.yml
+++ b/.github/workflows/notify-twitter.yml
@@ -1,0 +1,20 @@
+name: Notify twitter
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nearform/github-action-notify-twitter@v1
+        with:
+          message: |
+            ${{ github.event.repository.name }} ${{ github.event.release.tag_name }} has been released. Check out the release notes: ${{ github.event.release.html_url }} #opensource #jwt #fastjwt
+          twitter-app-key: ${{ secrets.TWITTER_APP_KEY }}
+          twitter-app-secret: ${{ secrets.TWITTER_APP_SECRET }}
+          twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+


### PR DESCRIPTION
Added `Notify Twitter` workflow that will push a tweet to [@NearFormOSS](https://twitter.com/NearFormOSS) upon successful release.

Closes #213 