### PR TITLE
Support Node v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^4.0.3"
   },
   "engines": {
-    "node": "^16 || ^14 || ^12"
+    "node": "^17 || ^16 || ^14 || ^12"
   },
   "tsd": {
     "directory": "test"


### PR DESCRIPTION
Just a quick pull request to add v17 of Node to the `engines.node` field in `package.json`.
Is there any problems with this?