### PR TITLE
fix: `aud` in SignerOptions should accept array of strings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -74,7 +74,7 @@ export interface SignerOptions {
   expiresIn: number
   notBefore: number
   jti: string
-  aud: string
+  aud: string | string[]
   iss: string
   sub: string
   nonce: string


### PR DESCRIPTION
According to the [README](https://github.com/nearform/fast-jwt/blob/master/README.md#createsigner), the signer options allows the `aud` option to be an array of strings. However, the corresponding TypeScript typing does not allow the property to be an array of strings. This PR fixes the typing error.

This PR fixes #262.