### PR TITLE
Change release action for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@v4
+      - uses: nearform/optic-release-automation-action@fix/fix-release-not-being-created
         with:
           github-token: ${{ secrets.github_token }}
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}


### PR DESCRIPTION
Change optic-release-automation-action version to test version to debug issue where release draft is not being created