### PR TITLE
chore: use set to check supported algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 
 .clinic
 .nyc_output

--- a/src/signer.js
+++ b/src/signer.js
@@ -15,9 +15,9 @@ const { TokenError } = require('./error')
 const { getAsyncKey, ensurePromiseCallback } = require('./utils')
 const { createPrivateKey, createSecretKey } = require('crypto')
 
-const supportedAlgorithms = Array.from(
-  new Set([...hsAlgorithms, ...esAlgorithms, ...rsaAlgorithms, ...edAlgorithms, 'none'])
-).join(', ')
+const supportedAlgorithms = new Set([...hsAlgorithms, ...esAlgorithms, ...rsaAlgorithms, ...edAlgorithms, 'none'])
+
+const supportedAlgorithmsList = Array.from(supportedAlgorithms).join(', ')
 
 function checkIsCompatibleAlgorithm(expected, actual) {
   const expectedType = expected.slice(0, 2)
@@ -193,15 +193,11 @@ module.exports = function createSigner(options) {
   // Validate options
   if (
     algorithm &&
-    algorithm !== 'none' &&
-    !hsAlgorithms.includes(algorithm) &&
-    !esAlgorithms.includes(algorithm) &&
-    !rsaAlgorithms.includes(algorithm) &&
-    !edAlgorithms.includes(algorithm)
+    !supportedAlgorithms.has(algorithm)
   ) {
     throw new TokenError(
       TokenError.codes.invalidOption,
-      `The algorithm option must be one of the following values: ${supportedAlgorithms}.`
+      `The algorithm option must be one of the following values: ${supportedAlgorithmsList}.`
     )
   }
 

--- a/src/signer.js
+++ b/src/signer.js
@@ -281,8 +281,11 @@ module.exports = function createSigner(options) {
   }
 
   const fpo = { jti, aud, iss, sub, nonce }
-  const fixedPayload = Object.keys(fpo).reduce((obj, key) => {
-    return fpo[key] !== undefined ? Object.assign(obj, { [key]: fpo[key] }) : obj
+  const fixedPayload = Object.entries(fpo).reduce((obj, [key, value]) => {
+    if (value !== undefined) {
+      obj[key] = value
+    }
+    return obj
   }, {})
 
   // Return the signer


### PR DESCRIPTION
With this PR I would like to remove all the slow `.includes` checks in favour of a single `Set.has` method, which should be faster.

Additionally, I'm modifying `Object.keys` to `Object.entries` in order to avoid extracting the value multiple times.

Here are the benchmarks:
- BEFORE
```
╔══════════════════════════════╤═════════╤═════════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ HS512 - jsonwebtoken (async) │    1500 │  1512.00 op/sec │  ± 0.72 % │                         ║
║ HS512 - jsonwebtoken (sync)  │    1000 │  1591.16 op/sec │  ± 0.36 % │ + 5.24 %                ║
║ HS512 - jose (sync)          │    1000 │ 38467.34 op/sec │  ± 0.68 % │ + 2444.13 %             ║
║ HS512 - fast-jwt (async)     │    1500 │ 42592.47 op/sec │  ± 0.87 % │ + 2716.95 %             ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ HS512 - fast-jwt (sync)      │    1000 │ 62009.46 op/sec │  ± 0.63 % │ + 4001.14 %             ║
╚══════════════════════════════╧═════════╧═════════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ ES512 - jsonwebtoken (async) │    1000 │ 364.88 op/sec │  ± 0.43 % │                         ║
║ ES512 - jsonwebtoken (sync)  │    1000 │ 382.12 op/sec │  ± 0.32 % │ + 4.72 %                ║
║ ES512 - fast-jwt (async)     │    1000 │ 390.38 op/sec │  ± 0.18 % │ + 6.99 %                ║
║ ES512 - fast-jwt (sync)      │    1000 │ 502.33 op/sec │  ± 0.23 % │ + 37.67 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ ES512 - jose (sync)          │    1000 │ 525.78 op/sec │  ± 0.26 % │ + 44.09 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - jsonwebtoken (async) │    1000 │ 195.39 op/sec │  ± 0.28 % │                         ║
║ RS512 - fast-jwt (async)     │    1000 │ 195.88 op/sec │  ± 0.25 % │ + 0.25 %                ║
║ RS512 - jsonwebtoken (sync)  │    1000 │ 199.52 op/sec │  ± 0.22 % │ + 2.12 %                ║
║ RS512 - jose (sync)          │    1000 │ 277.08 op/sec │  ± 0.35 % │ + 41.81 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - fast-jwt (sync)      │    1000 │ 294.34 op/sec │  ± 0.25 % │ + 50.65 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - jsonwebtoken (sync)  │    2000 │ 178.82 op/sec │  ± 0.80 % │                         ║
║ PS512 - jsonwebtoken (async) │    1000 │ 188.48 op/sec │  ± 0.33 % │ + 5.41 %                ║
║ PS512 - fast-jwt (async)     │    1000 │ 199.05 op/sec │  ± 0.22 % │ + 11.31 %               ║
║ PS512 - fast-jwt (sync)      │    1000 │ 270.58 op/sec │  ± 0.38 % │ + 51.32 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - jose (sync)          │    1000 │ 292.18 op/sec │  ± 0.25 % │ + 63.40 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════╤═════════╤═════════════════╤═══════════╤═════════════════════════╗
║ Slower tests             │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ EdDSA - fast-jwt (async) │    1000 │  1373.22 op/sec │  ± 0.50 % │                         ║
║ EdDSA - jose (sync)      │    1000 │ 13479.69 op/sec │  ± 0.19 % │ + 881.61 %              ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ Fastest test             │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ EdDSA - fast-jwt (sync)  │    1000 │ 17333.15 op/sec │  ± 0.69 % │ + 1162.23 %             ║
```

- AFTER
```
╔══════════════════════════════╤═════════╤═════════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ HS512 - jsonwebtoken (sync)  │    1000 │  1618.35 op/sec │  ± 0.40 % │                         ║
║ HS512 - jsonwebtoken (async) │    1000 │  1659.90 op/sec │  ± 0.36 % │ + 2.57 %                ║
║ HS512 - jose (sync)          │   10000 │ 40755.02 op/sec │  ± 3.67 % │ + 2418.30 %             ║
║ HS512 - fast-jwt (async)     │    1000 │ 45365.37 op/sec │  ± 0.91 % │ + 2703.18 %             ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ HS512 - fast-jwt (sync)      │    1500 │ 67367.14 op/sec │  ± 0.91 % │ + 4062.70 %             ║
╚══════════════════════════════╧═════════╧═════════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ ES512 - jsonwebtoken (async) │    1000 │ 381.50 op/sec │  ± 0.38 % │                         ║
║ ES512 - jsonwebtoken (sync)  │    1000 │ 386.17 op/sec │  ± 0.32 % │ + 1.22 %                ║
║ ES512 - fast-jwt (async)     │    1000 │ 397.46 op/sec │  ± 0.21 % │ + 4.18 %                ║
║ ES512 - fast-jwt (sync)      │    1000 │ 491.83 op/sec │  ± 0.76 % │ + 28.92 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ ES512 - jose (sync)          │    1000 │ 528.29 op/sec │  ± 0.29 % │ + 38.48 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - jsonwebtoken (async) │    1000 │ 183.00 op/sec │  ± 0.37 % │                         ║
║ RS512 - fast-jwt (async)     │    1000 │ 196.80 op/sec │  ± 0.23 % │ + 7.54 %                ║
║ RS512 - jsonwebtoken (sync)  │    1000 │ 201.66 op/sec │  ± 0.21 % │ + 10.20 %               ║
║ RS512 - fast-jwt (sync)      │    1000 │ 296.16 op/sec │  ± 0.34 % │ + 61.84 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - jose (sync)          │    1000 │ 302.76 op/sec │  ± 0.25 % │ + 65.44 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - jsonwebtoken (async) │    1000 │ 194.27 op/sec │  ± 0.30 % │                         ║
║ PS512 - jsonwebtoken (sync)  │    1000 │ 200.83 op/sec │  ± 0.20 % │ + 3.38 %                ║
║ PS512 - fast-jwt (async)     │    1000 │ 202.54 op/sec │  ± 0.18 % │ + 4.25 %                ║
║ PS512 - jose (sync)          │    1000 │ 297.68 op/sec │  ± 0.25 % │ + 53.23 %               ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                 │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - fast-jwt (sync)      │    1000 │ 303.92 op/sec │  ± 0.24 % │ + 56.44 %               ║
╚══════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔══════════════════════════╤═════════╤═════════════════╤═══════════╤═════════════════════════╗
║ Slower tests             │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ EdDSA - fast-jwt (async) │    1000 │  1464.05 op/sec │  ± 0.70 % │                         ║
║ EdDSA - jose (sync)      │    1000 │ 15903.05 op/sec │  ± 0.45 % │ + 986.24 %              ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ Fastest test             │ Samples │          Result │ Tolerance │ Difference with slowest ║
╟──────────────────────────┼─────────┼─────────────────┼───────────┼─────────────────────────╢
║ EdDSA - fast-jwt (sync)  │    1000 │ 17395.55 op/sec │  ± 0.43 % │ + 1088.18 %             ║
```