### PR TITLE
feat: additional tool in sign benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mnemonist": "^0.39.5"
   },
   "devDependencies": {
+    "@node-rs/jsonwebtoken": "^0.2.0",
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^5.49.0",


### PR DESCRIPTION
Additional tool in the benchmark, this time for the sign operation.

This has been added to demonstrate the speed of [napi-rs](https://napi.rs/).

```
╔═══════════════════════════════════════╤═════════╤══════════════════╤═══════════╤═════════════════════════╗
║ Slower tests                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ HS512 - jsonwebtoken (async)          │    1000 │   3643.83 op/sec │  ± 0.30 % │                         ║
║ HS512 - jsonwebtoken (sync)           │    1000 │   3663.59 op/sec │  ± 0.44 % │ + 0.54 %                ║
║ HS512 - @node-rs/jsonwebtoken (async) │    2000 │  84971.86 op/sec │  ± 0.95 % │ + 2231.94 %             ║
║ HS512 - jose (sync)                   │    1000 │ 112085.71 op/sec │  ± 0.91 % │ + 2976.04 %             ║
║ HS512 - fast-jwt (async)              │   10000 │ 120363.11 op/sec │  ± 4.74 % │ + 3203.21 %             ║
║ HS512 - fast-jwt (sync)               │    2000 │ 196243.45 op/sec │  ± 0.81 % │ + 5285.64 %             ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ Fastest test                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ HS512 - @node-rs/jsonwebtoken (sync)  │    1500 │ 243140.80 op/sec │  ± 0.76 % │ + 6572.68 %             ║
╚═══════════════════════════════════════╧═════════╧══════════════════╧═══════════╧═════════════════════════╝

╔═══════════════════════════════════════╤═════════╤══════════════════╤═══════════╤═════════════════════════╗
║ Slower tests                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ ES512 - jsonwebtoken (sync)           │    1000 │    508.65 op/sec │  ± 0.24 % │                         ║
║ ES512 - jsonwebtoken (async)          │    1000 │    516.55 op/sec │  ± 0.28 % │ + 1.55 %                ║
║ ES512 - fast-jwt (async)              │    1000 │    531.83 op/sec │  ± 0.17 % │ + 4.56 %                ║
║ ES512 - fast-jwt (sync)               │    1000 │    650.10 op/sec │  ± 0.18 % │ + 27.81 %               ║
║ ES512 - jose (sync)                   │    1000 │    659.42 op/sec │  ± 0.13 % │ + 29.64 %               ║
║ ES512 - @node-rs/jsonwebtoken (async) │    5000 │  83724.21 op/sec │  ± 0.96 % │ + 16359.99 %            ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ Fastest test                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ ES512 - @node-rs/jsonwebtoken (sync)  │    4000 │ 248971.42 op/sec │  ± 0.96 % │ + 48847.23 %            ║
╚═══════════════════════════════════════╧═════════╧══════════════════╧═══════════╧═════════════════════════╝

╔═══════════════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                          │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - jsonwebtoken (async)          │    1000 │ 207.59 op/sec │  ± 0.13 % │                         ║
║ RS512 - fast-jwt (async)              │    1000 │ 211.79 op/sec │  ± 0.12 % │ + 2.03 %                ║
║ RS512 - jsonwebtoken (sync)           │    1000 │ 212.31 op/sec │  ± 0.11 % │ + 2.27 %                ║
║ RS512 - jose (sync)                   │    1000 │ 274.84 op/sec │  ± 0.16 % │ + 32.40 %               ║
║ RS512 - fast-jwt (sync)               │    1000 │ 279.25 op/sec │  ± 0.15 % │ + 34.52 %               ║
║ RS512 - @node-rs/jsonwebtoken (async) │    1000 │ 292.44 op/sec │  ± 0.05 % │ + 40.88 %               ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                          │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ RS512 - @node-rs/jsonwebtoken (sync)  │    1000 │ 293.68 op/sec │  ± 0.06 % │ + 41.47 %               ║
╚═══════════════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔═══════════════════════════════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests                          │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - jsonwebtoken (async)          │    1000 │ 211.44 op/sec │  ± 0.11 % │                         ║
║ PS512 - fast-jwt (async)              │    1000 │ 212.84 op/sec │  ± 0.10 % │ + 0.67 %                ║
║ PS512 - jsonwebtoken (sync)           │    1000 │ 214.02 op/sec │  ± 0.09 % │ + 1.22 %                ║
║ PS512 - jose (sync)                   │    1000 │ 280.13 op/sec │  ± 0.14 % │ + 32.49 %               ║
║ PS512 - fast-jwt (sync)               │    1000 │ 281.55 op/sec │  ± 0.14 % │ + 33.16 %               ║
║ PS512 - @node-rs/jsonwebtoken (sync)  │    1000 │ 291.37 op/sec │  ± 0.29 % │ + 37.80 %               ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test                          │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ PS512 - @node-rs/jsonwebtoken (async) │    1000 │ 292.28 op/sec │  ± 0.09 % │ + 38.23 %               ║
╚═══════════════════════════════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

╔═══════════════════════════════════════╤═════════╤══════════════════╤═══════════╤═════════════════════════╗
║ Slower tests                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ EdDSA - fast-jwt (async)              │    1000 │   2969.04 op/sec │  ± 0.61 % │                         ║
║ EdDSA - jose (sync)                   │   10000 │  24855.81 op/sec │  ± 1.20 % │ + 737.17 %              ║
║ EdDSA - fast-jwt (sync)               │   10000 │  28710.81 op/sec │  ± 1.12 % │ + 867.01 %              ║
║ EdDSA - @node-rs/jsonwebtoken (async) │    1000 │  93635.27 op/sec │  ± 0.82 % │ + 3053.73 %             ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ Fastest test                          │ Samples │           Result │ Tolerance │ Difference with slowest ║
╟───────────────────────────────────────┼─────────┼──────────────────┼───────────┼─────────────────────────╢
║ EdDSA - @node-rs/jsonwebtoken (sync)  │    1500 │ 264904.64 op/sec │  ± 0.99 % │ + 8822.24 %             ║
╚═══════════════════════════════════════╧═════════╧══════════════════╧═══════════╧═════════════════════════╝
```