### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmarks/keys/generate-keys.js
+++ b/benchmarks/keys/generate-keys.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const { generateKeyPair } = require('crypto')
-const { writeFileSync } = require('fs')
-const { resolve } = require('path')
+const { generateKeyPair } = require('node:crypto')
+const { writeFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 
 const passProtectedKeyPassphrase = 'secret'
 const configurations = {

--- a/benchmarks/keys/generate-tokens.js
+++ b/benchmarks/keys/generate-tokens.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { readFileSync } = require('fs')
-const { resolve } = require('path')
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 
 const { createSigner } = require('../../src')
 

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -14,8 +14,8 @@ const {
     RSA_PSS_SALTLEN_MAX_SIGN,
     RSA_PSS_SALTLEN_AUTO
   }
-} = require('crypto')
-let { sign: directSign, verify: directVerify } = require('crypto')
+} = require('node:crypto')
+let { sign: directSign, verify: directVerify } = require('node:crypto')
 const { joseToDer, derToJose } = require('ecdsa-sig-formatter')
 const Cache = require('mnemonist/lru-cache')
 const { TokenError } = require('./error')

--- a/src/signer.js
+++ b/src/signer.js
@@ -13,7 +13,7 @@ const {
 } = require('./crypto')
 const { TokenError } = require('./error')
 const { getAsyncKey, ensurePromiseCallback } = require('./utils')
-const { createPrivateKey, createSecretKey } = require('crypto')
+const { createPrivateKey, createSecretKey } = require('node:crypto')
 const { parse: parseMs } = require('@lukeed/ms')
 
 const supportedAlgorithms = new Set([...hsAlgorithms, ...esAlgorithms, ...rsaAlgorithms, ...edAlgorithms, 'none'])

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createHash } = require('crypto')
+const { createHash } = require('node:crypto')
 const algorithmMatcher = /"alg"\s*:\s*"[HERP]S(256|384)"/m
 const edAlgorithmMatcher = /"alg"\s*:\s*"EdDSA"/m
 const ed448CurveMatcher = /"crv"\s*:\s*"Ed448"/m

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createPublicKey, createSecretKey } = require('crypto')
+const { createPublicKey, createSecretKey } = require('node:crypto')
 const Cache = require('mnemonist/lru-cache')
 
 const { useNewCrypto, hsAlgorithms, verifySignature, detectPublicKeyAlgorithms } = require('./crypto')

--- a/test/compatibility.spec.js
+++ b/test/compatibility.spec.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { readFileSync } = require('fs')
+const { readFileSync } = require('node:fs')
 const { sign: jsonwebtokenSign, verify: jsonwebtokenVerify } = require('jsonwebtoken')
 const {
   JWT: { sign: joseSign, verify: joseVerify },
   JWK: { asKey }
 } = require('jose')
-const { resolve } = require('path')
+const { resolve } = require('node:path')
 const { test } = require('tap')
 
 const { createSigner, createVerifier } = require('../src')

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const { test } = require('tap')
-const { readFileSync } = require('fs')
-const { resolve } = require('path')
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 
 const { createVerifier, createSigner } = require('../src')
 const {

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { readFileSync } = require('fs')
-const { resolve } = require('path')
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 const { test } = require('tap')
 
 const { createSigner, createVerifier, TokenError, createDecoder } = require('../src')

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { createHash } = require('crypto')
-const { readFileSync } = require('fs')
-const { resolve } = require('path')
+const { createHash } = require('node:crypto')
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 const { test } = require('tap')
 const { install: fakeTime } = require('@sinonjs/fake-timers')
 


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).