### PR TITLE
fix: removed pre publish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "src"
   ],
   "scripts": {
-    "prepublishOnly": "npm run test:ci",
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint src/**/*.js test/**/*.js src/**/*.ts test/**/*.ts",
     "test": "tap --reporter=spec --coverage-report=html --coverage-report=text --100 --no-browser test/*.spec.js test/**/*.spec.js && tsd",


### PR DESCRIPTION
Removed the pre-publish step to run tests, since the time delay caused by running these tests can cause the release to fail due to the optic token expiring. The repo needs to pass CI anyway for the release to be successful, so this step was unnecessary.
closes https://github.com/nearform/fast-jwt/issues/368