### PR TITLE
fix: add missingRequiredClaim to TokenValidationErrorCode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ export type TokenValidationErrorCode =
   | 'FAST_JWT_KEY_FETCHING_ERROR'
   | 'FAST_JWT_SIGN_ERROR'
   | 'FAST_JWT_VERIFY_ERROR'
+  | 'FAST_JWT_MISSING_REQUIRED_CLAIM'
   | 'FAST_JWT_MISSING_SIGNATURE'
 
 declare class TokenError extends Error {
@@ -52,6 +53,7 @@ declare class TokenError extends Error {
     keyFetchingError: 'FAST_JWT_KEY_FETCHING_ERROR'
     signError: 'FAST_JWT_SIGN_ERROR'
     verifyError: 'FAST_JWT_VERIFY_ERROR'
+    missingRequiredClaim: 'FAST_JWT_MISSING_REQUIRED_CLAIM'
     missingSignature: 'FAST_JWT_MISSING_SIGNATURE'
   }
 

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -3,8 +3,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { createDecoder, createSigner, createVerifier, DecodedJwt, JwtHeader, TokenError } from '..'
-import { expectAssignable, expectNotAssignable } from 'tsd'
+import { createDecoder, createSigner, createVerifier, DecodedJwt, JwtHeader, TokenError, TokenValidationErrorCode } from '..'
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 
 // Signing
 // Buffer key, both async/callback styles
@@ -105,3 +105,6 @@ const signerOptionsNoAlg = {
   }
 }
 expectNotAssignable<JwtHeader>(signerOptionsNoAlg.header)
+
+// Check all errors are typed correctly
+expectType<TokenValidationErrorCode[]>(Object.values(TokenError.codes))


### PR DESCRIPTION
This better reflects the actual source implementation and fixes #402.

The unit test is somewhat brittle, since it's too trusting of the .d.ts types. I don't know how to overcome this limitation without just typing the whole project properly