### PR TITLE
remove unnecessary import in declaration file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,3 @@
-import 'node'
-
 export type Algorithm =
   | 'none'
   | 'HS256'


### PR DESCRIPTION
Hi,

i was trying out @fastify/jwt in a new project. I have noticed my eslint rule "import/no-cycle" was failing,
because it can't resolve the import.

```
[Error - 23:34:21] EslintPluginImportResolveError: unable to load resolver "node".
Occurred while linting /app/src/plugins/auth/authorization.ts:2
Rule: "import/no-cycle"
    at requireResolver (/app/node_modules/eslint-module-utils/resolve.js:201:17)
    at fullResolve (/app/node_modules/eslint-module-utils/resolve.js:141:22)
    at Function.relative (/app/node_modules/eslint-module-utils/resolve.js:158:10)
    at remotePath (/app/node_modules/eslint-plugin-import/lib/ExportMap.js:811:381)
    at captureDependency (/app/node_modules/eslint-plugin-import/lib/ExportMap.js:817:463)
    at captureDependencyWithSpecifiers (/app/node_modules/eslint-plugin-import/lib/ExportMap.js:817:144)
    at /app/node_modules/eslint-plugin-import/lib/ExportMap.js:822:42
    at Array.forEach (<anonymous>)
    at ExportMap.parse (/app/node_modules/eslint-plugin-import/lib/ExportMap.js:821:427)
    at ExportMap.for (/app/node_modules/eslint-plugin-import/lib/ExportMap.js:807:201)
```

I don't have enough experiance in typescript. It can be possible the import exists for older versions.
if that case, you can close the PR and sorry for the inconvenience.

Issue: #472

Thanks 

