### PR TITLE
feat: deprecate use new crypto

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -15,12 +15,10 @@ const {
     RSA_PSS_SALTLEN_AUTO
   }
 } = require('node:crypto')
-let { sign: directSign, verify: directVerify } = require('node:crypto')
+const { sign: directSign, verify: directVerify } = require('node:crypto')
 const { joseToDer, derToJose } = require('ecdsa-sig-formatter')
 const Cache = require('mnemonist/lru-cache')
 const { TokenError } = require('./error')
-
-const useNewCrypto = typeof directSign === 'function'
 
 const base64UrlMatcher = /[=+/]/g
 const encoderMap = { '=': '', '+': '-', '/': '_' }
@@ -40,19 +38,6 @@ const ecCurves = {
   '1.3.132.0.10': { bits: '256', names: ['secp256k1'] },
   '1.3.132.0.34': { bits: '384', names: ['P-384', 'secp384r1'] },
   '1.3.132.0.35': { bits: '512', names: ['P-521', 'secp521r1'] }
-}
-
-/* istanbul ignore next */
-if (!useNewCrypto) {
-  directSign = function (alg, data, options) {
-    if (typeof alg === 'undefined') {
-      throw new TokenError(TokenError.codes.signError, 'EdDSA algorithms are not supported by your Node.js version.')
-    }
-
-    return createSign(alg)
-      .update(data)
-      .sign(options)
-  }
 }
 
 const PrivateKey = asn.define('PrivateKey', function () {
@@ -351,7 +336,6 @@ function verifySignature(algorithm, key, input, signature) {
 }
 
 module.exports = {
-  useNewCrypto,
   base64UrlMatcher,
   base64UrlReplacer,
   hsAlgorithms,

--- a/src/signer.js
+++ b/src/signer.js
@@ -3,7 +3,6 @@
 const {
   base64UrlMatcher,
   base64UrlReplacer,
-  useNewCrypto,
   hsAlgorithms,
   esAlgorithms,
   rsaAlgorithms,
@@ -45,13 +44,7 @@ function prepareKeyOrSecret(key, algorithm) {
     key = Buffer.from(key, 'utf-8')
   }
 
-  // Only on Node 12 - Create a key object
-  /* istanbul ignore next */
-  if (useNewCrypto) {
-    key = algorithm[0] === 'H' ? createSecretKey(key) : createPrivateKey(key)
-  }
-
-  return key
+  return algorithm[0] === 'H' ? createSecretKey(key) : createPrivateKey(key)
 }
 
 function sign(

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -3,7 +3,7 @@
 const { createPublicKey, createSecretKey } = require('node:crypto')
 const Cache = require('mnemonist/lru-cache')
 
-const { useNewCrypto, hsAlgorithms, verifySignature, detectPublicKeyAlgorithms } = require('./crypto')
+const { hsAlgorithms, verifySignature, detectPublicKeyAlgorithms } = require('./crypto')
 const createDecoder = require('./decoder')
 const { TokenError } = require('./error')
 const { getAsyncKey, ensurePromiseCallback, hashToken } = require('./utils')
@@ -39,13 +39,7 @@ function prepareKeyOrSecret(key, isSecret) {
     key = Buffer.from(key, 'utf-8')
   }
 
-  // Only on Node 12 - Create a key object
-  /* istanbul ignore next */
-  if (useNewCrypto) {
-    key = isSecret ? createSecretKey(key) : createPublicKey(key)
-  }
-
-  return key
+  return isSecret ? createSecretKey(key) : createPublicKey(key)
 }
 
 function ensureStringClaimMatcher(raw) {

--- a/test/compatibility.spec.js
+++ b/test/compatibility.spec.js
@@ -10,7 +10,6 @@ const { resolve } = require('node:path')
 const { test } = require('node:test')
 
 const { createSigner, createVerifier } = require('../src')
-const { useNewCrypto } = require('../src/crypto')
 
 const privateKeys = {
   HS: 'secretsecretsecret',
@@ -56,25 +55,23 @@ for (const type of ['HS', 'ES', 'RS', 'PS']) {
   }
 }
 
-if (useNewCrypto) {
-  for (const curve of ['Ed25519', 'Ed448']) {
-    test(`fast-jwt should correcty verify tokens created by jose - EdDSA with ${curve}`, t => {
-      const verify = createVerifier({ key: publicKeys[curve].toString() })
-      const token = joseSign({ a: 1, b: 2, c: 3 }, asKey(privateKeys[curve]), {
-        iat: false,
-        header: {
-          typ: 'JWT'
-        }
-      })
-
-      t.assert.deepStrictEqual(verify(token), { a: 1, b: 2, c: 3 })
+for (const curve of ['Ed25519', 'Ed448']) {
+  test(`fast-jwt should correcty verify tokens created by jose - EdDSA with ${curve}`, t => {
+    const verify = createVerifier({ key: publicKeys[curve].toString() })
+    const token = joseSign({ a: 1, b: 2, c: 3 }, asKey(privateKeys[curve]), {
+      iat: false,
+      header: {
+        typ: 'JWT'
+      }
     })
 
-    test(`jose should correcty verify tokens created by fast-jwt - EdDSA with ${curve}`, t => {
-      const signer = createSigner({ key: privateKeys[curve], noTimestamp: true })
-      const token = signer({ a: 1, b: 2, c: 3 })
+    t.assert.deepStrictEqual(verify(token), { a: 1, b: 2, c: 3 })
+  })
 
-      t.assert.deepStrictEqual(joseVerify(token, asKey(publicKeys[curve])), { a: 1, b: 2, c: 3 })
-    })
-  }
+  test(`jose should correcty verify tokens created by fast-jwt - EdDSA with ${curve}`, t => {
+    const signer = createSigner({ key: privateKeys[curve], noTimestamp: true })
+    const token = signer({ a: 1, b: 2, c: 3 })
+
+    t.assert.deepStrictEqual(joseVerify(token, asKey(publicKeys[curve])), { a: 1, b: 2, c: 3 })
+  })
 }

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -6,7 +6,6 @@ const {
 } = require('jose')
 
 const { createVerifier, createSigner } = require('../src')
-const { useNewCrypto } = require('../src/crypto')
 
 const payload = {
   text: "It’s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there’s no knowing where you might be swept off to."
@@ -142,30 +141,28 @@ test('ES512', t => {
   t.assert.equal(token.replace(/\..+/, ''), expectedToken.replace(/\..+/, ''))
 })
 
-if (useNewCrypto) {
-  // All the keys here are extracted from https://tools.ietf.org/html/rfc8037
-  const ed25519PublicKey = asKey({
-    kty: 'OKP',
-    crv: 'Ed25519',
-    x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo'
-  }).toPEM()
+// All the keys here are extracted from https://tools.ietf.org/html/rfc8037
+const ed25519PublicKey = asKey({
+  kty: 'OKP',
+  crv: 'Ed25519',
+  x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo'
+}).toPEM()
 
-  const ed25519PrivateKey = asKey({
-    kty: 'OKP',
-    crv: 'Ed25519',
-    d: 'nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A',
-    x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo'
-  }).toPEM(true)
+const ed25519PrivateKey = asKey({
+  kty: 'OKP',
+  crv: 'Ed25519',
+  d: 'nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A',
+  x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo'
+}).toPEM(true)
 
-  test('EdDSA - Ed25519', t => {
-    const expectedToken =
-      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ0ZXh0IjoiSXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4ifQ.s6A86zrJs551R4UxXwJsfRCGswdTJYFeNWjHUkZvragJ7hN43T5UetbpG4S6L2G7wOq5N_JJKrkbs0q0Gd-EAQ'
+test('EdDSA - Ed25519', t => {
+  const expectedToken =
+    'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ0ZXh0IjoiSXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4ifQ.s6A86zrJs551R4UxXwJsfRCGswdTJYFeNWjHUkZvragJ7hN43T5UetbpG4S6L2G7wOq5N_JJKrkbs0q0Gd-EAQ'
 
-    const token = createSigner({ algorithm: 'EdDSA', key: ed25519PrivateKey, noTimestamp: true })(payload)
+  const token = createSigner({ algorithm: 'EdDSA', key: ed25519PrivateKey, noTimestamp: true })(payload)
 
-    const verified = createVerifier({ key: ed25519PublicKey })(token)
+  const verified = createVerifier({ key: ed25519PublicKey })(token)
 
-    t.assert.deepStrictEqual(verified, payload)
-    t.assert.equal(token, expectedToken)
-  })
-}
+  t.assert.deepStrictEqual(verified, payload)
+  t.assert.equal(token, expectedToken)
+})

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -5,7 +5,6 @@ const { resolve } = require('node:path')
 const { test } = require('node:test')
 
 const { createSigner, createVerifier, TokenError, createDecoder } = require('../src')
-const { useNewCrypto } = require('../src/crypto')
 
 const privateKeys = {
   HS: 'secretsecretsecret',
@@ -79,19 +78,10 @@ test('it correctly returns a token - sync', async t => {
     'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhIjoxfQ.'
   )
 
-  if (useNewCrypto) {
-    t.assert.equal(
-      sign({ a: 1 }, { noTimestamp: true, key: privateKeys.Ed25519 }),
-      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.pIRjmLR-JW4sTCslD24h5fs0sTUpGYBG7zh4Z_UyEZ_u29NojdH2dSNKQZwwgjl1WvfYNtBCCF_EnYTazAXmDQ'
-    )
-  } else {
-    t.assert.throws(() => sign({ a: 1 }, { noTimestamp: true, key: privateKeys.Ed25519 }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'EdDSA algorithms are not supported by your Node.js version.'
-      }
-    })
-  }
+  t.assert.equal(
+    sign({ a: 1 }, { noTimestamp: true, key: privateKeys.Ed25519 }),
+    'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.pIRjmLR-JW4sTCslD24h5fs0sTUpGYBG7zh4Z_UyEZ_u29NojdH2dSNKQZwwgjl1WvfYNtBCCF_EnYTazAXmDQ'
+  )
 })
 
 test('it correctly returns a token - async - key with callback', async t => {
@@ -127,92 +117,47 @@ test('it correctly returns a token - callback - key as promise', t => {
 
 test('it correctly returns a token - key as an RSA X509 key', async t => {
   const payload = { a: 1 }
-  if (useNewCrypto) {
-    const signedToken = sign(payload, { key: privateKeys.RSX509, noTimestamp: true })
-    const decoder = createDecoder()
-    const result = decoder(signedToken)
+  const signedToken = sign(payload, { key: privateKeys.RSX509, noTimestamp: true })
+  const decoder = createDecoder()
+  const result = decoder(signedToken)
 
-    t.assert.equal(payload.a, result.a)
-  } else {
-    t.assert.throws(() => sign(payload, { key: privateKeys.RSX509 }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'The "key" argument must be one of type string, Buffer, TypedArray, or DataView. Received type object'
-      }
-    })
-  }
+  t.assert.equal(payload.a, result.a)
 })
 
 test('it correctly returns a token - key as an RSA passphrase protected key', async t => {
   const payload = { a: 1 }
-  if (useNewCrypto) {
-    const signedToken = sign(payload, { algorithm: 'RS256', key: { key: privateKeys.PPRS, passphrase: 'secret' } })
-    const decoder = createDecoder()
-    const result = decoder(signedToken)
+  const signedToken = sign(payload, { algorithm: 'RS256', key: { key: privateKeys.PPRS, passphrase: 'secret' } })
+  const decoder = createDecoder()
+  const result = decoder(signedToken)
 
-    t.assert.equal(payload.a, result.a)
-  } else {
-    t.assert.throws(() => sign(payload, { key: { key: privateKeys.PPRS, passphrase: 'secret' } }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'The "key" argument must be one of type string, Buffer, TypedArray, or DataView. Received type object'
-      }
-    })
-  }
+  t.assert.equal(payload.a, result.a)
 })
 
 test('it correctly returns a token - key as an ES256 passphrase protected key', async t => {
   const payload = { a: 1 }
-  if (useNewCrypto) {
-    const signedToken = sign(payload, { algorithm: 'ES256', key: { key: privateKeys.PPES256, passphrase: 'secret' } })
-    const decoder = createDecoder()
-    const result = decoder(signedToken)
+  const signedToken = sign(payload, { algorithm: 'ES256', key: { key: privateKeys.PPES256, passphrase: 'secret' } })
+  const decoder = createDecoder()
+  const result = decoder(signedToken)
 
-    t.assert.equal(payload.a, result.a)
-  } else {
-    t.assert.throws(() => sign(payload, { key: { key: privateKeys.PPES256, passphrase: 'secret' } }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'The "key" argument must be one of type string, Buffer, TypedArray, or DataView. Received type object'
-      }
-    })
-  }
+  t.assert.equal(payload.a, result.a)
 })
 
 test('it correctly returns a token - key as an ES384 passphrase protected key', async t => {
   const payload = { a: 1 }
-  if (useNewCrypto) {
-    const signedToken = sign(payload, { algorithm: 'ES384', key: { key: privateKeys.PPES384, passphrase: 'secret' } })
-    const decoder = createDecoder()
-    const result = decoder(signedToken)
+  const signedToken = sign(payload, { algorithm: 'ES384', key: { key: privateKeys.PPES384, passphrase: 'secret' } })
+  const decoder = createDecoder()
+  const result = decoder(signedToken)
 
-    t.assert.equal(payload.a, result.a)
-  } else {
-    t.assert.throws(() => sign(payload, { key: { key: privateKeys.PPES384, passphrase: 'secret' } }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'The "key" argument must be one of type string, Buffer, TypedArray, or DataView. Received type object'
-      }
-    })
-  }
+  t.assert.equal(payload.a, result.a)
 })
 
 test('it correctly returns a token - key as an ES512 passphrase protected key', async t => {
   const payload = { a: 1 }
-  if (useNewCrypto) {
-    const signedToken = sign(payload, { algorithm: 'ES512', key: { key: privateKeys.PPES512, passphrase: 'secret' } })
-    const decoder = createDecoder()
-    const result = decoder(signedToken)
+  const signedToken = sign(payload, { algorithm: 'ES512', key: { key: privateKeys.PPES512, passphrase: 'secret' } })
+  const decoder = createDecoder()
+  const result = decoder(signedToken)
 
-    t.assert.equal(payload.a, result.a)
-  } else {
-    t.assert.throws(() => sign(payload, { key: { key: privateKeys.PPES512, passphrase: 'secret' } }), {
-      message: 'Cannot create the signature.',
-      originalError: {
-        message: 'The "key" argument must be one of type string, Buffer, TypedArray, or DataView. Received type object'
-      }
-    })
-  }
+  t.assert.equal(payload.a, result.a)
 })
 
 test('it correctly returns an error when algorithm is not provided when using passphrase protected key', async t => {
@@ -273,31 +218,29 @@ test('it correctly autodetects the algorithm depending on the secret provided', 
   verification = es512Verifier(token)
   t.assert.equal(verification.header.alg, 'ES512')
 
-  if (useNewCrypto) {
-    token = createSigner({ algorithm: 'RS256', key: { key: privateKeys.PPRS, passphrase: 'secret' } })({ a: 1 })
-    verification = pprsVerifier(token)
-    t.assert.equal(verification.header.alg, 'RS256')
+  token = createSigner({ algorithm: 'RS256', key: { key: privateKeys.PPRS, passphrase: 'secret' } })({ a: 1 })
+  verification = pprsVerifier(token)
+  t.assert.equal(verification.header.alg, 'RS256')
 
-    token = createSigner({ algorithm: 'ES256', key: { key: privateKeys.PPES256, passphrase: 'secret' } })({ a: 1 })
-    verification = ppes256Verifier(token)
-    t.assert.equal(verification.header.alg, 'ES256')
+  token = createSigner({ algorithm: 'ES256', key: { key: privateKeys.PPES256, passphrase: 'secret' } })({ a: 1 })
+  verification = ppes256Verifier(token)
+  t.assert.equal(verification.header.alg, 'ES256')
 
-    token = createSigner({ algorithm: 'ES384', key: { key: privateKeys.PPES384, passphrase: 'secret' } })({ a: 1 })
-    verification = ppes384Verifier(token)
-    t.assert.equal(verification.header.alg, 'ES384')
+  token = createSigner({ algorithm: 'ES384', key: { key: privateKeys.PPES384, passphrase: 'secret' } })({ a: 1 })
+  verification = ppes384Verifier(token)
+  t.assert.equal(verification.header.alg, 'ES384')
 
-    token = createSigner({ algorithm: 'ES512', key: { key: privateKeys.PPES512, passphrase: 'secret' } })({ a: 1 })
-    verification = ppes512Verifier(token)
-    t.assert.equal(verification.header.alg, 'ES512')
+  token = createSigner({ algorithm: 'ES512', key: { key: privateKeys.PPES512, passphrase: 'secret' } })({ a: 1 })
+  verification = ppes512Verifier(token)
+  t.assert.equal(verification.header.alg, 'ES512')
 
-    token = createSigner({ key: privateKeys.Ed25519 })({ a: 1 })
-    verification = es25519Verifier(token)
-    t.assert.equal(verification.header.alg, 'EdDSA')
+  token = createSigner({ key: privateKeys.Ed25519 })({ a: 1 })
+  verification = es25519Verifier(token)
+  t.assert.equal(verification.header.alg, 'EdDSA')
 
-    token = createSigner({ key: privateKeys.Ed448 })({ a: 1 })
-    verification = es448Verifier(token)
-    t.assert.equal(verification.header.alg, 'EdDSA')
-  }
+  token = createSigner({ key: privateKeys.Ed448 })({ a: 1 })
+  verification = es448Verifier(token)
+  t.assert.equal(verification.header.alg, 'EdDSA')
 })
 
 test('it correctly set a timestamp', async t => {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -7,7 +7,6 @@ const { test } = require('node:test')
 const { install: fakeTime } = require('@sinonjs/fake-timers')
 
 const { createSigner, createVerifier, TokenError } = require('../src')
-const { useNewCrypto } = require('../src/crypto')
 const { hashToken } = require('../src/utils')
 
 const privateKeys = {
@@ -120,29 +119,13 @@ test('it correctly verifies a token - sync', t => {
     }
   )
 
-  if (useNewCrypto) {
-    t.assert.deepStrictEqual(
-      verify(
-        'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkifQ.eyJhIjoxfQ.n4isU7JqaKRVOyx2ni7b_iaAzB75pAUCW6CetcoClhtJ5yDM7YkNMbKqmDUhTKMpupAcztIjX8m4mZwpA33HAA',
-        { key: publicKeys.Ed25519 }
-      ),
-      { a: 1 }
-    )
-  } else {
-    t.assert.throws(
-      () =>
-        verify(
-          'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkifQ.eyJhIjoxfQ.n4isU7JqaKRVOyx2ni7b_iaAzB75pAUCW6CetcoClhtJ5yDM7YkNMbKqmDUhTKMpupAcztIjX8m4mZwpA33HAA',
-          { key: publicKeys.Ed25519 }
-        ),
-      {
-        message: 'Cannot verify the signature.',
-        originalError: {
-          message: 'EdDSA algorithms are not supported by your Node.js version.'
-        }
-      }
-    )
-  }
+  t.assert.deepStrictEqual(
+    verify(
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkifQ.eyJhIjoxfQ.n4isU7JqaKRVOyx2ni7b_iaAzB75pAUCW6CetcoClhtJ5yDM7YkNMbKqmDUhTKMpupAcztIjX8m4mZwpA33HAA',
+      { key: publicKeys.Ed25519 }
+    ),
+    { a: 1 }
+  )
 })
 
 test('it correctly verifies a token - async - key with callback', async t => {
@@ -1062,34 +1045,32 @@ for (const type of ['HS', 'ES', 'RS', 'PS']) {
   }
 }
 
-if (useNewCrypto) {
-  test('caching - should use the right hash method for storing values - EdDSA with Ed25519', t => {
-    const signer = createSigner({ algorithm: 'EdDSA', key: privateKeys.Ed25519, noTimestamp: 1 })
-    const verifier = createVerifier({ key: publicKeys.Ed25519, cache: true })
-    const token = signer({ a: 1 })
-    const hash = createHash('sha512').update(token).digest('hex')
+test('caching - should use the right hash method for storing values - EdDSA with Ed25519', t => {
+  const signer = createSigner({ algorithm: 'EdDSA', key: privateKeys.Ed25519, noTimestamp: 1 })
+  const verifier = createVerifier({ key: publicKeys.Ed25519, cache: true })
+  const token = signer({ a: 1 })
+  const hash = createHash('sha512').update(token).digest('hex')
 
-    t.assert.deepStrictEqual(verifier(token), { a: 1 })
-    t.assert.equal(verifier.cache.size, 1)
-    t.assert.equal(Array.from(verifier.cache.keys())[0], hash)
+  t.assert.deepStrictEqual(verifier(token), { a: 1 })
+  t.assert.equal(verifier.cache.size, 1)
+  t.assert.equal(Array.from(verifier.cache.keys())[0], hash)
+})
+
+test('caching - should use the right hash method for storing values - EdDSA with Ed448', t => {
+  const signer = createSigner({
+    algorithm: 'EdDSA',
+    key: privateKeys.Ed448,
+    noTimestamp: 1,
+    header: { crv: 'Ed448' }
   })
+  const verifier = createVerifier({ key: publicKeys.Ed448, cache: true })
+  const token = signer({ a: 1 })
+  const hash = createHash('shake256', { outputLength: 114 }).update(token).digest('hex')
 
-  test('caching - should use the right hash method for storing values - EdDSA with Ed448', t => {
-    const signer = createSigner({
-      algorithm: 'EdDSA',
-      key: privateKeys.Ed448,
-      noTimestamp: 1,
-      header: { crv: 'Ed448' }
-    })
-    const verifier = createVerifier({ key: publicKeys.Ed448, cache: true })
-    const token = signer({ a: 1 })
-    const hash = createHash('shake256', { outputLength: 114 }).update(token).digest('hex')
-
-    t.assert.deepStrictEqual(verifier(token), { a: 1 })
-    t.assert.equal(verifier.cache.size, 1)
-    t.assert.equal(Array.from(verifier.cache.keys())[0], hash)
-  })
-}
+  t.assert.deepStrictEqual(verifier(token), { a: 1 })
+  t.assert.equal(verifier.cache.size, 1)
+  t.assert.equal(Array.from(verifier.cache.keys())[0], hash)
+})
 
 test('caching - should be able to manipulate cache directy', t => {
   const clock = fakeTime({ now: 100000 })


### PR DESCRIPTION
Now that we support just Node 20+, we can remove all the checks that relies on `useNewCrypto`