### PR TITLE
chore(types): Add missing input type for DecodedJwt and Updated input field to return decoded 'input'

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,7 +65,8 @@ type VerifierCallback = (e: Error | TokenError | null, payload: any) => void
 type DecodedJwt = {
   header: Record<string, any>
   payload: any
-  signature: string
+  signature: string,
+  input: string
 }
 
 type KeyFetcher =

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -288,7 +288,7 @@ function verify(
     throw e
   }
 
-  const { header, payload, signature } = decoded
+  const { header, payload, signature, input } = decoded
   const cacheContext = {
     cache,
     token,
@@ -309,7 +309,7 @@ function verify(
     try {
       verifyToken(key, decoded, validationContext)
 
-      return cacheSet(cacheContext, complete ? { header, payload, signature, input: token } : payload)
+      return cacheSet(cacheContext, complete ? { header, payload, signature, input } : payload)
     } catch (e) {
       throw cacheSet(cacheContext, e)
     }

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -137,3 +137,16 @@ expectNotAssignable<JwtHeader>(signerOptionsNoAlg.header)
 
 // Check all errors are typed correctly
 expectType<TokenValidationErrorCode[]>(Object.values(TokenError.codes))
+
+const decodedJwt: DecodedJwt = {
+  header: { alg: 'RS256', typ: 'JWT' },
+  payload: { sub: '12345', iss: 'iss' },
+  signature: 'abc123',
+  input: 'sample-token'
+}
+
+expectType<DecodedJwt>(decodedJwt)
+expectType<Record<string, any>>(decodedJwt.header)
+expectType<any>(decodedJwt.payload)
+expectType<string>(decodedJwt.signature)
+expectType<string>(decodedJwt.input)

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -142,7 +142,7 @@ const decodedJwt: DecodedJwt = {
   header: { alg: 'RS256', typ: 'JWT' },
   payload: { sub: '12345', iss: 'iss' },
   signature: 'abc123',
-  input: 'sample-token'
+  input: 'input'
 }
 
 expectType<DecodedJwt>(decodedJwt)

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -117,7 +117,7 @@ test('it correctly verifies a token - sync', t => {
       header: { typ: 'JWT', alg: 'HS256' },
       payload: { a: 1 },
       signature: '57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM',
-      input: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM'
+      input: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ'
     }
   )
 


### PR DESCRIPTION
This PR adds missing `input: string` field in `DecodedJwt` type.
Also fixed to return decoded input field rather than whole token.
Also, Updating types as per [comment]( https://github.com/nearform/fast-jwt/issues/521#issuecomment-2536672724)

Fixes: #521

