### PR TITLE
Incorrect Handling of Timestamps in exp, nbf, and iat Claims in fast-jwt

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -88,14 +88,15 @@ function sign(
   let encodedPayload = ''
 
   // Add claims
-  const iat = payload.iat * 1000 || clockTimestamp || Date.now()
-
+  const iat = payload.iat * 1000 || clockTimestamp || Date.now(); // Handle `iat` in milliseconds
+  const iatSec = (iat / 1000); // Convert `iat` to seconds
+  
   const finalPayload = {
-    ...payload,
-    ...fixedPayload,
-    iat: noTimestamp ? undefined : Math.floor(iat / 1000),
-    exp: payload.exp ? payload.exp : expiresIn ? Math.floor((iat + expiresIn) / 1000) : undefined,
-    nbf: payload.nbf ? payload.nbf : notBefore ? Math.floor((iat + notBefore) / 1000) : undefined
+      ...payload,
+      ...fixedPayload,
+      iat: noTimestamp ? undefined : Math.floor(iatSec),
+      exp: payload.exp ? payload.exp : expiresIn ? Math.floor(iatSec + expiresIn) : undefined,
+      nbf: payload.nbf ? payload.nbf : notBefore ? Math.floor(iatSec + notBefore) : undefined
   }
 
   if (mutatePayload) {


### PR DESCRIPTION
There is an issue in `fast-jwt` where the `exp`, `nbf`, and `iat` claims are incorrectly calculated when `expiresIn` is provided in seconds. Specifically, the issue arises when `payload.iat` is in milliseconds, but `expiresIn` is in seconds, which results in incorrect expiration calculations.

[Issue: Incorrect Handling of Timestamps - 549](https://github.com/nearform/fast-jwt/issues/549)