### PR TITLE
feat!: align claim validation to specification

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -141,12 +141,12 @@ function validateAlgorithmAndSignature(input, header, signature, key, allowedAlg
   }
 }
 
-function validateClaimType(values, claim, allowArray, arrayValue, type) {
+function validateClaimType(values, claim, allowArray, isArray, type) {
   const typeFailureMessage = allowArray
     ? `The ${claim} claim must be a ${type} or an array of ${type}s.`
     : `The ${claim} claim must be a ${type}.`
 
-  if (arrayValue && !allowArray) {
+  if (isArray && !allowArray) {
     throw new TokenError(TokenError.codes.invalidClaimValue, typeFailureMessage)
   }
 
@@ -155,8 +155,8 @@ function validateClaimType(values, claim, allowArray, arrayValue, type) {
   }
 }
 
-function validateClaimValues(values, claim, allowed, arrayValue) {
-  const failureMessage = arrayValue
+function validateClaimValues(values, claim, allowed, isArray) {
+  const failureMessage = isArray
     ? `None of ${claim} claim values are allowed.`
     : `The ${claim} claim value is not allowed.`
 
@@ -212,8 +212,8 @@ function verifyToken(
 
   for (const { type, claim, allowed, array, modifier, greater, errorCode, errorVerb } of validators) {
     const value = payload[claim]
-    const arrayValue = Array.isArray(value)
-    const values = arrayValue ? value : [value]
+    const isArray = Array.isArray(value)
+    const values = isArray ? value : [value]
 
     // We have already checked above that all required claims are present
     // Therefore we can skip this validator if the claim is not present
@@ -222,12 +222,12 @@ function verifyToken(
     }
 
     // Validate type
-    validateClaimType(values, claim, array, arrayValue, type === 'date' ? 'number' : 'string')
+    validateClaimType(values, claim, array, isArray, type === 'date' ? 'number' : 'string')
 
     if (type === 'date') {
       validateClaimDateValue(value, modifier, now, greater, errorCode, errorVerb)
     } else {
-      validateClaimValues(values, claim, allowed, arrayValue)
+      validateClaimValues(values, claim, allowed, isArray)
     }
   }
 }

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -227,7 +227,7 @@ function verifyToken(
     if (type === 'date') {
       validateClaimDateValue(value, modifier, now, greater, errorCode, errorVerb)
     } else {
-      validateClaimValues(values, claim, allowed, arrayValue, array)
+      validateClaimValues(values, claim, allowed, arrayValue)
     }
   }
 }

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -653,6 +653,24 @@ test('it validates the aud claim only if explicitily enabled', t => {
   token = sign({
     a: 1,
     jti: 'JTI',
+    aud: 'AUD',
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedAud: 'AUD' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: 'AUD',
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+
+  token = sign({
+    a: 1,
+    jti: 'JTI',
     aud: ['AUD1', 'DUA2'],
     iss: 'ISS',
     sub: 'SUB',
@@ -681,6 +699,24 @@ test('it validates the aud claim only if explicitily enabled', t => {
     iat: 100,
     jti: 'JTI',
     aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: 'DUA2',
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedAud: ['ABX', /^D/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: 'DUA2',
     iss: 'ISS',
     sub: 'SUB',
     nonce: 'NONCE'

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -470,518 +470,524 @@ test('it validates if the token has not expired including the clock tolerance', 
 })
 
 test('it validates the jti claim only if explicitily enabled', t => {
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6MiwiaXNzIjozLCJzdWIiOjQsIm5vbmNlIjo1fQ.J-oaiNMlIJfH1jlNZcRjcEXdG5La4lKGjYtoLMs8vKM',
-        { allowedJti: 'JTI1' }
-      )
-    },
-    { message: 'The jti claim must be a string.' }
-  )
+  t.mock.timers.enable({ now: 100000 })
+  const sign = createSigner({ key: 'secret' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedJti: 'JTI1' }
-      )
-    },
-    { message: 'The jti claim value is not allowed.' }
-  )
+  let token = sign({
+    a: 1,
+    jti: 1,
+    aud: 2,
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedJti: 'JTI1' }), { message: 'The jti claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedJti: [/abc/, 'cde'] }
-      )
-    },
-    { message: 'The jti claim value is not allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: ['JTI', 'JTI1'],
+    aud: ['AUD1'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedJti: ['JTI'] }), { message: 'The jti claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOlsiSlRJIiwiSlRJMSJdLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.H2GACKIYvauUswRaK3SVsSwUOTjEcQDb1Qj_iCuLWoM',
-        { allowedJti: ['JTI'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The jti claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedJti: 'JTI1' }), { message: 'The jti claim value is not allowed.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOlsiSlRJIiwiSlRJMSJdLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.H2GACKIYvauUswRaK3SVsSwUOTjEcQDb1Qj_iCuLWoM',
-        { allowedJti: ['JTI', 'JTI2'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The jti claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedJti: [/abc/, 'cde'] }), {
+    message: 'The jti claim value is not allowed.'
+  })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOlsiSlRJIiwiSlRJMSJdLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.H2GACKIYvauUswRaK3SVsSwUOTjEcQDb1Qj_iCuLWoM',
-        { allowedJti: ['JTI', 'JTI1'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The jti claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedJti: 'JTI' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedJti: 'JTI' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedJti: ['ABX', 'JTI'] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedJti: ['ABX', 'JTI'] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
-
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedJti: ['ABX', /^J/] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedJti: ['ABX', /^J/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 })
 
 test('it validates the aud claim only if explicitily enabled', t => {
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6MiwiaXNzIjozLCJzdWIiOjQsIm5vbmNlIjo1fQ.J-oaiNMlIJfH1jlNZcRjcEXdG5La4lKGjYtoLMs8vKM',
-        { allowedAud: 'AUD2' }
-      )
-    },
-    { message: 'The aud claim must be a string or an array of strings.' }
-  )
+  t.mock.timers.enable({ now: 100000 })
+  const sign = createSigner({ key: 'secret' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6WzIuMSwyLjJdLCJpc3MiOjMsInN1YiI6NCwibm9uY2UiOjV9._qE95j2r4UQ8BEXGZRv9stn5OLg1I3nQBEV4WKdABMg',
-        { allowedAud: 'AUD2' }
-      )
-    },
-    { message: 'The aud claim must be a string or an array of strings.' }
-  )
+  let token = sign({
+    a: 1,
+    jti: 1,
+    aud: 2,
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedAud: 'AUD2' }), {
+    message: 'The aud claim must be a string or an array of strings.'
+  })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedAud: 'AUD2' }
-      )
-    },
-    { message: 'None of aud claim values are allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 1,
+    aud: [2.1, 2.2],
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedAud: 'AUD2' }), {
+    message: 'The aud claim must be a string or an array of strings.'
+  })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedAud: [/abc/, 'cde'] }
-      )
-    },
-    { message: 'None of aud claim values are allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 1,
+    aud: ['AUD', 2.2],
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedAud: 'AUD2' }), {
+    message: 'The aud claim must be a string or an array of strings.'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEIiwiRFVBMiJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.lhu5t694BY0QmF7SChUw7Z9nUPtupWCkhrQ2rqN06GU',
-      { allowedAud: 'AUD' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedAud: 'AUD2' }), { message: 'None of aud claim values are allowed.' })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedAud: ['ABX', 'AUD1'] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedAud: [/abc/, 'cde'] }), {
+    message: 'None of aud claim values are allowed.'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedAud: ['ABX', /^D/] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedAud: 'AUD' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedAud: ['ABX', 'AUD1'] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedAud: ['ABX', /^D/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 })
 
 test('it validates the iss claim only if explicitily enabled', t => {
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6MiwiaXNzIjozLCJzdWIiOjQsIm5vbmNlIjo1fQ.J-oaiNMlIJfH1jlNZcRjcEXdG5La4lKGjYtoLMs8vKM',
-        { allowedIss: 'ISS1' }
-      )
-    },
-    { message: 'The iss claim must be a string.' }
-  )
+  t.mock.timers.enable({ now: 100000 })
+  const sign = createSigner({ key: 'secret' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedIss: 'ISS1' }
-      )
-    },
-    { message: 'The iss claim value is not allowed.' }
-  )
+  let token = sign({
+    a: 1,
+    jti: 1,
+    aud: 2,
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedIss: 'ISS1' }), { message: 'The iss claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedIss: [/abc/, 'cde'] }
-      )
-    },
-    { message: 'The iss claim value is not allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1'],
+    iss: ['ISS', 'ISS1'],
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedIss: ['ISS'] }), { message: 'The iss claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOlsiSVNTIiwiSVNTMSJdLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.IS9XILuqYEAKycN8j2MT0121j19T02CbW_h0erVh5IE',
-        { allowedIss: ['ISS'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The iss claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedIss: 'ISS1' }), { message: 'The iss claim value is not allowed.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOlsiSVNTIiwiSVNTMSJdLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.IS9XILuqYEAKycN8j2MT0121j19T02CbW_h0erVh5IE',
-        { allowedIss: ['ISS', 'ISS2'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The iss claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedIss: [/abc/, 'cde'] }), {
+    message: 'The iss claim value is not allowed.'
+  })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOlsiSVNTIiwiSVNTMSJdLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.IS9XILuqYEAKycN8j2MT0121j19T02CbW_h0erVh5IE',
-        { allowedIss: ['ISS', 'ISS1'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The iss claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedIss: 'ISS' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedIss: 'ISS' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedIss: ['ABX', 'ISS'] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedIss: ['ABX', 'ISS'] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
-
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedIss: ['ABX', /^I/] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedIss: ['ABX', /^I/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 })
 
 test('it validates the sub claim only if explicitily enabled', t => {
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6MiwiaXNzIjozLCJzdWIiOjQsIm5vbmNlIjo1fQ.J-oaiNMlIJfH1jlNZcRjcEXdG5La4lKGjYtoLMs8vKM',
-        { allowedSub: 'SUB1' }
-      )
-    },
-    { message: 'The sub claim must be a string.' }
-  )
+  t.mock.timers.enable({ now: 100000 })
+  const sign = createSigner({ key: 'secret' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedSub: 'SUB1' }
-      )
-    },
-    { message: 'The sub claim value is not allowed.' }
-  )
+  let token = sign({
+    a: 1,
+    jti: 1,
+    aud: 2,
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedSub: 'SUB1' }), { message: 'The sub claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedSub: [/abc/, 'cde'] }
-      )
-    },
-    { message: 'The sub claim value is not allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedSub: 'SUB1' }), { message: 'The sub claim value is not allowed.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOlsiU1VCMSIsIlNVQjIiXSwibm9uY2UiOiJOT05DRSJ9.RwBpdTCEFCxO0jIFPnJpxjRd0JVIhP2Eettmsh0uwzY',
-        { allowedSub: ['SUB1'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The sub claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedSub: [/abc/, 'cde'] }), {
+    message: 'The sub claim value is not allowed.'
+  })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOlsiU1VCMSIsIlNVQjIiXSwibm9uY2UiOiJOT05DRSJ9.RwBpdTCEFCxO0jIFPnJpxjRd0JVIhP2Eettmsh0uwzY',
-        { allowedSub: ['SUB1', 'SUB3'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The sub claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1'],
+    iss: 'ISS',
+    sub: ['SUB1', 'SUB2'],
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedSub: ['SUB1'] }), { message: 'The sub claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOlsiU1VCMSIsIlNVQjIiXSwibm9uY2UiOiJOT05DRSJ9.RwBpdTCEFCxO0jIFPnJpxjRd0JVIhP2Eettmsh0uwzY',
-        { allowedSub: ['SUB1', 'SUB2'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The sub claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedSub: 'SUB' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedSub: 'SUB' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedSub: ['ABX', 'SUB'] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedSub: ['ABX', 'SUB'] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
-
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedSub: ['ABX', /^S/] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedSub: ['ABX', /^S/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 })
 
 test('it validates the nonce claim only if explicitily enabled', t => {
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOjEsImF1ZCI6MiwiaXNzIjozLCJzdWIiOjQsIm5vbmNlIjo1fQ.J-oaiNMlIJfH1jlNZcRjcEXdG5La4lKGjYtoLMs8vKM',
-        { allowedNonce: 'NONCE1' }
-      )
-    },
-    { message: 'The nonce claim must be a string.' }
-  )
+  t.mock.timers.enable({ now: 100000 })
+  const sign = createSigner({ key: 'secret' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedNonce: 'NONCE1' }
-      )
-    },
-    { message: 'The nonce claim value is not allowed.' }
-  )
+  let token = sign({
+    a: 1,
+    jti: 1,
+    aud: 2,
+    iss: 3,
+    sub: 4,
+    nonce: 5
+  })
+  t.assert.throws(() => verify(token, { allowedNonce: 'NONCE1' }), { message: 'The nonce claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-        { allowedNonce: [/abc/, 'cde'] }
-      )
-    },
-    { message: 'The nonce claim value is not allowed.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: ['NONCE', 'NONCE1']
+  })
+  t.assert.throws(() => verify(token, { allowedNonce: ['NONCE'] }), { message: 'The nonce claim must be a string.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6WyJOT05DRSIsIk5PTkNFMSJdfQ.a8ZSzXebJvaw32jyWgbBo9aeLNTgs_sqxD2llV4f8KQ',
-        { allowedNonce: ['NONCE'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The nonce claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedNonce: 'NONCE1' }), { message: 'The nonce claim value is not allowed.' })
 
-  t.assert.throws(
-    () => {
-      return verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6WyJOT05DRSIsIk5PTkNFMSJdfQ.a8ZSzXebJvaw32jyWgbBo9aeLNTgs_sqxD2llV4f8KQ',
-        { allowedNonce: ['NONCE', 'NONCE2'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The nonce claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.throws(() => verify(token, { allowedNonce: [/abc/, 'cde'] }), {
+    message: 'The nonce claim value is not allowed.'
+  })
 
-  t.assert.throws(
-    () => {
-      verify(
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6WyJOT05DRSIsIk5PTkNFMSJdfQ.a8ZSzXebJvaw32jyWgbBo9aeLNTgs_sqxD2llV4f8KQ',
-        { allowedNonce: ['NONCE', 'NONCE1'], key: 'secret-secret-secret-secret-secret' }
-      )
-    },
-    { message: 'The nonce claim must be a string.' }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedNonce: 'NONCE' }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedNonce: 'NONCE' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedNonce: ['ABX', 'NONCE'] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedNonce: ['ABX', 'NONCE'] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
-
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSIsIkRVQTIiXSwiaXNzIjoiSVNTIiwic3ViIjoiU1VCIiwibm9uY2UiOiJOT05DRSJ9.8fqzi23J-GjaD7rW3OYJv8UtBYkx8MOkViJjS4sXmVw',
-      { allowedNonce: ['ABX', /^N/] }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1', 'DUA2'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
-  )
+  token = sign({
+    a: 1,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
+  t.assert.deepStrictEqual(verify(token, { allowedNonce: ['ABX', /^N/] }), {
+    a: 1,
+    iat: 100,
+    jti: 'JTI',
+    aud: ['AUD1', 'DUA2'],
+    iss: 'ISS',
+    sub: 'SUB',
+    nonce: 'NONCE'
+  })
 })
 
 test('it validates allowed claims values using equality when appropriate', t => {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -507,7 +507,7 @@ test('it validates the jti claim only if explicitily enabled', t => {
         { allowedJti: ['JTI'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the jti claim values are allowed.' }
+    { message: 'The jti claim must be a string.' }
   )
 
   t.assert.throws(
@@ -517,22 +517,17 @@ test('it validates the jti claim only if explicitily enabled', t => {
         { allowedJti: ['JTI', 'JTI2'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the jti claim values are allowed.' }
+    { message: 'The jti claim must be a string.' }
   )
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOlsiSlRJIiwiSlRJMSJdLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.H2GACKIYvauUswRaK3SVsSwUOTjEcQDb1Qj_iCuLWoM',
-      { allowedJti: ['JTI', 'JTI1'], key: 'secret-secret-secret-secret-secret' }
-    ),
-    {
-      a: 1,
-      jti: ['JTI', 'JTI1'],
-      aud: ['AUD1'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
+  t.assert.throws(
+    () => {
+      return verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOlsiSlRJIiwiSlRJMSJdLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.H2GACKIYvauUswRaK3SVsSwUOTjEcQDb1Qj_iCuLWoM',
+        { allowedJti: ['JTI', 'JTI1'], key: 'secret-secret-secret-secret-secret' }
+      )
+    },
+    { message: 'The jti claim must be a string.' }
   )
 
   t.assert.deepStrictEqual(
@@ -706,7 +701,7 @@ test('it validates the iss claim only if explicitily enabled', t => {
         { allowedIss: ['ISS'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the iss claim values are allowed.' }
+    { message: 'The iss claim must be a string.' }
   )
 
   t.assert.throws(
@@ -716,22 +711,17 @@ test('it validates the iss claim only if explicitily enabled', t => {
         { allowedIss: ['ISS', 'ISS2'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the iss claim values are allowed.' }
+    { message: 'The iss claim must be a string.' }
   )
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOlsiSVNTIiwiSVNTMSJdLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.IS9XILuqYEAKycN8j2MT0121j19T02CbW_h0erVh5IE',
-      { allowedIss: ['ISS', 'ISS1'], key: 'secret-secret-secret-secret-secret' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1'],
-      iss: ['ISS', 'ISS1'],
-      sub: 'SUB',
-      nonce: 'NONCE'
-    }
+  t.assert.throws(
+    () => {
+      return verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOlsiSVNTIiwiSVNTMSJdLCJzdWIiOiJTVUIiLCJub25jZSI6Ik5PTkNFIn0.IS9XILuqYEAKycN8j2MT0121j19T02CbW_h0erVh5IE',
+        { allowedIss: ['ISS', 'ISS1'], key: 'secret-secret-secret-secret-secret' }
+      )
+    },
+    { message: 'The iss claim must be a string.' }
   )
 
   t.assert.deepStrictEqual(
@@ -818,7 +808,7 @@ test('it validates the sub claim only if explicitily enabled', t => {
         { allowedSub: ['SUB1'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the sub claim values are allowed.' }
+    { message: 'The sub claim must be a string.' }
   )
 
   t.assert.throws(
@@ -828,22 +818,17 @@ test('it validates the sub claim only if explicitily enabled', t => {
         { allowedSub: ['SUB1', 'SUB3'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the sub claim values are allowed.' }
+    { message: 'The sub claim must be a string.' }
   )
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOlsiU1VCMSIsIlNVQjIiXSwibm9uY2UiOiJOT05DRSJ9.RwBpdTCEFCxO0jIFPnJpxjRd0JVIhP2Eettmsh0uwzY',
-      { allowedSub: ['SUB1', 'SUB2'], key: 'secret-secret-secret-secret-secret' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1'],
-      iss: 'ISS',
-      sub: ['SUB1', 'SUB2'],
-      nonce: 'NONCE'
-    }
+  t.assert.throws(
+    () => {
+      verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOlsiU1VCMSIsIlNVQjIiXSwibm9uY2UiOiJOT05DRSJ9.RwBpdTCEFCxO0jIFPnJpxjRd0JVIhP2Eettmsh0uwzY',
+        { allowedSub: ['SUB1', 'SUB2'], key: 'secret-secret-secret-secret-secret' }
+      )
+    },
+    { message: 'The sub claim must be a string.' }
   )
 
   t.assert.deepStrictEqual(
@@ -930,7 +915,7 @@ test('it validates the nonce claim only if explicitily enabled', t => {
         { allowedNonce: ['NONCE'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the nonce claim values are allowed.' }
+    { message: 'The nonce claim must be a string.' }
   )
 
   t.assert.throws(
@@ -940,22 +925,17 @@ test('it validates the nonce claim only if explicitily enabled', t => {
         { allowedNonce: ['NONCE', 'NONCE2'], key: 'secret-secret-secret-secret-secret' }
       )
     },
-    { message: 'Not all of the nonce claim values are allowed.' }
+    { message: 'The nonce claim must be a string.' }
   )
 
-  t.assert.deepStrictEqual(
-    verify(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6WyJOT05DRSIsIk5PTkNFMSJdfQ.a8ZSzXebJvaw32jyWgbBo9aeLNTgs_sqxD2llV4f8KQ',
-      { allowedNonce: ['NONCE', 'NONCE1'], key: 'secret-secret-secret-secret-secret' }
-    ),
-    {
-      a: 1,
-      jti: 'JTI',
-      aud: ['AUD1'],
-      iss: 'ISS',
-      sub: 'SUB',
-      nonce: ['NONCE', 'NONCE1']
-    }
+  t.assert.throws(
+    () => {
+      verify(
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJqdGkiOiJKVEkiLCJhdWQiOlsiQVVEMSJdLCJpc3MiOiJJU1MiLCJzdWIiOiJTVUIiLCJub25jZSI6WyJOT05DRSIsIk5PTkNFMSJdfQ.a8ZSzXebJvaw32jyWgbBo9aeLNTgs_sqxD2llV4f8KQ',
+        { allowedNonce: ['NONCE', 'NONCE1'], key: 'secret-secret-secret-secret-secret' }
+      )
+    },
+    { message: 'The nonce claim must be a string.' }
   )
 
   t.assert.deepStrictEqual(


### PR DESCRIPTION
BREAKING CHANGE
Enhances the claim validation to match the JWT specification by ensuring that claim values are strings and not arrays

Resolves https://github.com/nearform/fast-jwt/issues/552