### PR TITLE
feature: support negative expiresIn when signing tokens

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -235,7 +235,7 @@ module.exports = function createSigner(options) {
     if (typeof expiresIn === 'string') {
       expiresIn = parseMs(expiresIn)
     }
-    if (typeof expiresIn !== 'number' || expiresIn < 0) {
+    if (typeof expiresIn !== 'number') {
       throw new TokenError(
         TokenError.codes.invalidOption,
         'The expiresIn option must be a positive number or a valid string.'

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -297,6 +297,13 @@ test('it supports expiresIn as a string', async t => {
   )
 })
 
+test('it supports negative expiresIn', async t => {
+  t.assert.equal(
+    sign({ a: 1, iat: 100 }, { expiresIn: -1 }),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjo5OX0.KqZa0DfwU41PqeDTct_kWCUKXeyQpzJJSZhGd76TR40'
+  )
+})
+
 test('it adds the payload exp claim', async t => {
   t.assert.equal(
     sign({ a: 1, iat: 100, exp: 200 }, {}),
@@ -596,10 +603,6 @@ test('options validation - expiresIn', async t => {
   })
 
   t.assert.throws(() => createSigner({ key: 'secret', expiresIn: 'invalid string' }), {
-    message: 'The expiresIn option must be a positive number or a valid string.'
-  })
-
-  t.assert.throws(() => createSigner({ key: 'secret', expiresIn: -1 }), {
     message: 'The expiresIn option must be a positive number or a valid string.'
   })
 })

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -297,7 +297,7 @@ test('it supports expiresIn as a string', async t => {
   )
 })
 
-test('it supports negative expiresIn', async t => {
+test('it supports negative expiresIn value', async t => {
   t.assert.equal(
     sign({ a: 1, iat: 100 }, { expiresIn: -1 }),
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjo5OX0.KqZa0DfwU41PqeDTct_kWCUKXeyQpzJJSZhGd76TR40'

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -469,6 +469,13 @@ test('it validates if the token has not expired including the clock tolerance', 
   )
 })
 
+test('rejects token with negative exp', t => {
+  t.mock.timers.enable({ now: 0 })
+  const token = createSigner({ key: 'secret', expiresIn: -120000 })({ a: 1 })
+
+  t.assert.throws(() => verify(token), { message: 'The token has expired at 1969-12-31T23:58:00.000Z.' })
+})
+
 test('it validates the jti claim only if explicitily enabled', t => {
   t.mock.timers.enable({ now: 100000 })
   const sign = createSigner({ key: 'secret' })


### PR DESCRIPTION
Supports negative `expiresIn` option when signing tokens

Resolves #555 