### PR TITLE
Fix: error constructor in declaration file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,6 +34,7 @@ export type TokenValidationErrorCode =
   | 'FAST_JWT_MISSING_SIGNATURE'
 
 declare class TokenError extends Error {
+  constructor(code: TokenValidationErrorCode, message?: string, additional?: { [key: string]: any });
   static wrap(originalError: Error, code: TokenValidationErrorCode, message: string): TokenError
   static codes: {
     invalidType: 'FAST_JWT_INVALID_TYPE'

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -103,6 +103,19 @@ createVerifier<Record<string, number>>({
 })({ key: 1 }).then(console.log, console.log)
 
 // Errors
+const errorWithNoMsg = new TokenError(TokenError.codes.expired)
+expectType<TokenError>(errorWithNoMsg)
+expectType<string>(errorWithNoMsg.message)
+
+const errorWithMsg = new TokenError(TokenError.codes.expired, 'MESSAGE')
+expectType<TokenError>(errorWithMsg)
+expectType<string>(errorWithMsg.message)
+
+const errorWithAdditional = new TokenError(TokenError.codes.expired, 'MESSAGE', { additional: 'data' })
+expectType<TokenError>(errorWithAdditional)
+expectType<string>(errorWithAdditional.message)
+expectType<any>(errorWithAdditional.additional)
+
 const wrapped = TokenError.wrap(new Error('ORIGINAL'), 'FAST_JWT_INVALID_TYPE', 'MESSAGE')
 wrapped.code === 'FAST_JWT_INVALID_TYPE'
 wrapped.message === 'MESSAGE'


### PR DESCRIPTION
I happened to run in to this when adding a UT on a project of mine, wanting to test that when a `TokenError` is thrown, the function handles it as expected.
To do that, I mocked the `createVerifier` and tried to mock the returned value to be a function that throws a `TokenError`, but then I saw the typing was wrong (as it just got the types of `Error`)