### PR TITLE
fix: skip public key detection for HSxxx algorithms

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -72,7 +72,7 @@ function cacheSet(cache, key, value, error) {
 }
 
 function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
-  if (providedAlgorithm && providedAlgorithm[0] === 'H') {
+  if (providedAlgorithm?.[0] === 'H') {
     // the key string might look like a public/private key, but it should be used as a raw string
     return providedAlgorithm
   }

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -71,7 +71,12 @@ function cacheSet(cache, key, value, error) {
   return value || error
 }
 
-function performDetectPrivateKeyAlgorithm(key) {
+function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
+  if (providedAlgorithm && providedAlgorithm[0] === 'H') {
+    // the key string might look like a public/private key, but it should be used as a raw string
+    return providedAlgorithm
+  }
+
   if (key.match(publicKeyPemMatcher) || key.includes(publicKeyX509CertMatcher)) {
     throw new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
   }
@@ -185,7 +190,7 @@ function detectPrivateKeyAlgorithm(key, providedAlgorithm) {
 
   // Try detecting
   try {
-    const detectedAlgorithm = performDetectPrivateKeyAlgorithm(key)
+    const detectedAlgorithm = performDetectPrivateKeyAlgorithm(key, providedAlgorithm)
 
     if (detectedAlgorithm === 'ENCRYPTED') {
       return cacheSet(privateKeysCache, key, providedAlgorithm)

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -72,7 +72,7 @@ function cacheSet(cache, key, value, error) {
 }
 
 function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
-  if (providedAlgorithm?.[0] === 'H') {
+  if (hsAlgorithms.includes(providedAlgorithm)) {
     // the key string might look like a public/private key, but it should be used as a raw string
     return providedAlgorithm
   }

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -143,6 +143,10 @@ test('detectPrivateKeyAlgorithm - public keys should be rejected', t => {
   })
 })
 
+test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256 is used', t => {
+  t.assert.equal(detectPrivateKeyAlgorithm("-----BEGIN PUBLIC KEY-----\nUSED IN HS256", 'HS256'), 'HS256')
+})
+
 test('detectPrivateKeyAlgorithm - unrecognized PKCS8 OIDs should be rejected', t => {
   t.assert.throws(() => detectPrivateKeyAlgorithm(invalidPrivatePKCS8), {
     message: 'Unsupported PEM PCKS8 private key with OID 1.2.840.10040.4.1.'
@@ -231,12 +235,13 @@ test('detectPublicKeyAlgorithms - unrecognized EC curves should be rejected', t 
 
 for (const bits of [256, 384, 512]) {
   const hsAlgorithm = `HS${bits}`
+  const key = privateKeys.HS
 
   // HS256, HS512, HS512
   test(`${hsAlgorithm} based tokens round trip with string keys`, t => {
-    const token = createSigner({ algorithm: hsAlgorithm, key: 'secretsecretsecret' })({ payload: 'PAYLOAD' })
+    const token = createSigner({ algorithm: hsAlgorithm, key })({ payload: 'PAYLOAD' })
 
-    const verified = createVerifier({ key: 'secretsecretsecret' })(token)
+    const verified = createVerifier({ key })(token)
 
     t.assert.equal(verified.payload, 'PAYLOAD')
     t.assert.ok(verified.iat >= start)
@@ -244,11 +249,11 @@ for (const bits of [256, 384, 512]) {
   })
 
   test(`${hsAlgorithm} based tokens round trip with buffer keys`, t => {
-    const token = createSigner({ algorithm: hsAlgorithm, key: Buffer.from('secretsecretsecret', 'utf-8') })({
+    const token = createSigner({ algorithm: hsAlgorithm, key: Buffer.from(key, 'utf-8') })({
       payload: 'PAYLOAD'
     })
 
-    const verified = createVerifier({ key: 'secretsecretsecret' })(token)
+    const verified = createVerifier({ key })(token)
 
     t.assert.equal(verified.payload, 'PAYLOAD')
     t.assert.ok(verified.iat >= start)

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -143,8 +143,8 @@ test('detectPrivateKeyAlgorithm - public keys should be rejected', t => {
   })
 })
 
-test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256, HS364, HS512 is used', t => {
-  ;['HS256', 'HS364', 'HS512'].forEach(algorithm => {
+test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256, HS384, HS512 is used', t => {
+  ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
     t.assert.equal(detectPrivateKeyAlgorithm(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, algorithm), algorithm)
   })
 })

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -144,8 +144,8 @@ test('detectPrivateKeyAlgorithm - public keys should be rejected', t => {
 })
 
 test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256, HS364, HS512 is used', t => {
-  ['HS256', 'HS364', 'HS512'].forEach((algorithm) => {
-    t.assert.equal(detectPrivateKeyAlgorithm(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, algorithhm), algorithm)
+  ;['HS256', 'HS364', 'HS512'].forEach(algorithm => {
+    t.assert.equal(detectPrivateKeyAlgorithm(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, algorithm), algorithm)
   })
 })
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -143,8 +143,10 @@ test('detectPrivateKeyAlgorithm - public keys should be rejected', t => {
   })
 })
 
-test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256 is used', t => {
-  t.assert.equal(detectPrivateKeyAlgorithm("-----BEGIN PUBLIC KEY-----\nUSED IN HS256", 'HS256'), 'HS256')
+test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256, HS364, HS512 is used', t => {
+  ['HS256', 'HS364', 'HS512'].forEach((algorithm) => {
+    t.assert.equal(detectPrivateKeyAlgorithm(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, algorithhm), algorithm)
+  })
 })
 
 test('detectPrivateKeyAlgorithm - unrecognized PKCS8 OIDs should be rejected', t => {


### PR DESCRIPTION
We use fast-jwt at Supabase and are very grateful for this library.

We ran into a problem recently where some HS256 keys used to sign JWTs look quite a lot like a public/private key. The library ignores the `algorithm: 'HS256'` indication and errors out with:

```js
new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
```

Instead, it should not try to parse the string if the developer has indicated the string or buffer is a HMAC secret only, regardless of what it contains.

Fixes #577 