### PR TITLE
fix: cache confusion risk with composite-key approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Create a verifier function by calling `createVerifier` and providing one or more
 
 - `clockTolerance`: Timespan in milliseconds is the tolerance to apply to the current timestamp when performing time comparisons. Default is `0`.
 
-- `cacheKeyBuilder`: The function that will be used to create the [cache's key](#caching) for each token. To mitigate the risk of leaking sensitive information and generate collisions, [a hashing function](./src/utils.js) is used by default. When using a custom function, users must be aware of the possible risks. Check the [Caching section](#caching) for more information.
+- `cacheKeyBuilder`: The function that will be used to create the [cache's key](#caching) for each token. To mitigate the risk of leaking sensitive information and reduce the risk of collisions, [a hashing function](./src/utils.js) is used by default. When using a custom function, users must be aware of the possible risks. Check the [Caching section](#caching) for more information.
 
 The verifier is a function which accepts a token (as Buffer or string) and returns the payload or the sections of the token.
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -516,7 +516,9 @@ module.exports = function createVerifier(options) {
 
   const allowedCritHeadersSet = new Set(allowedCritHeaders || [])
 
-  if (cacheSize && options?.cacheKeyBuilder) {
+  const cache = createCache(cacheSize)
+
+  if (cache && options?.cacheKeyBuilder) {
     process.emitWarning(
       'A custom cacheKeyBuilder is in use with caching enabled. ' +
         'Cache key collisions can lead to identity/authorization bypass. ' +
@@ -591,7 +593,7 @@ module.exports = function createVerifier(options) {
     isAsync: keyType === 'function',
     validators,
     decode: createDecoder({ complete: true }),
-    cache: createCache(cacheSize),
+    cache,
     requiredClaims,
     allowedCritHeaders: allowedCritHeadersSet,
     cacheKeyBuilder

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1197,19 +1197,25 @@ test('caching - sync - custom cacheKeyBuilder', t => {
 })
 
 test('caching - sync - custom cacheKeyBuilder emits security warning', async t => {
+  let onWarning
   const warningPromise = new Promise(resolve => {
-    const onWarning = w => {
+    onWarning = w => {
       if (w.code === 'FAST_JWT_CACHE_KEY_BUILDER_SECURITY_RISK') {
-        process.off('warning', onWarning)
         resolve(w)
       }
     }
     process.on('warning', onWarning)
   })
 
+  t.after(() => process.off('warning', onWarning))
+
   createVerifier({ key: 'secret', cache: true, cacheKeyBuilder: id => id })
 
-  const warning = await warningPromise
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Timed out waiting for FAST_JWT_CACHE_KEY_BUILDER_SECURITY_RISK warning')), 1000)
+  )
+
+  const warning = await Promise.race([warningPromise, timeout])
   t.assert.equal(warning.code, 'FAST_JWT_CACHE_KEY_BUILDER_SECURITY_RISK')
   t.assert.ok(warning.message.includes('cacheKeyBuilder'))
 })


### PR DESCRIPTION
## fix: prevent cache confusion via custom `cacheKeyBuilder` collisions

When `cache` is enabled with a custom `cacheKeyBuilder` that produces colliding keys,
the verifier could return a cached payload from a different token — leading to identity
confusion, privilege escalation, or cross-tenant data access.

### Fix

When a custom `cacheKeyBuilder` is provided a process warning is emitted with code FAST_JWT_CACHE_KEY_BUILDER_SECURITY_RISK. 
This warns users that a poorly implemented key builder can lead to cache collisions and identity/authorization bypass.

The README Caching section already had a [!WARNING] callout.

Tests added
- `caching - sync - custom cacheKeyBuilder emits security warning` — asserts the warning is emitted (with the correct code and message) when a custom `cacheKeyBuilder` is provided alongside `cache: true`.

- `caching - sync - default cacheKeyBuilder does not emit security warning` — asserts no warning is emitted when the default `hashToken` builder is used.


FIXES #588 