### PR TITLE
Add guard against 'null' token and token parts

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -22,6 +22,9 @@ function decode({ complete, checkTyp }, token) {
   let validHeader = false
   try {
     const header = JSON.parse(Buffer.from(token.slice(0, firstSeparator), 'base64').toString('utf-8'))
+    if (!header || typeof header !== 'object' || Array.isArray(header)) {
+      throw new TokenError(TokenError.codes.malformed, 'The token header is not a valid JSON object.')
+    }
     if (checkTyp && header.typ !== checkTyp) {
       throw new TokenError(TokenError.codes.invalidType, `The type must be "${checkTyp}".`, { header })
     }

--- a/src/signer.js
+++ b/src/signer.js
@@ -68,7 +68,7 @@ function sign(
   const [callback, promise] = isAsync ? ensurePromiseCallback(cb) : []
 
   // Validate payload
-  if (typeof payload !== 'object') {
+  if (payload === null || typeof payload !== 'object') {
     throw new TokenError(TokenError.codes.invalidType, 'The payload must be an object.')
   }
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -328,6 +328,16 @@ function verify(
 ) {
   const [callback, promise] = isAsync ? ensurePromiseCallback(cb) : []
 
+  // Validate token type before any processing
+  if (!(token instanceof Buffer) && typeof token !== 'string') {
+    const error = new TokenError(TokenError.codes.invalidType, 'The token must be a string or a buffer.')
+    if (callback) {
+      callback(error)
+      return promise
+    }
+    throw error
+  }
+
   // Check the cache
   if (cache) {
     const [value, min, max] = cache.get(cacheKeyBuilder(token)) || [undefined, 0, 0]

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -56,6 +56,26 @@ test('invalid header', t => {
   t.assert.throws(() => typDecoder(nonJwtToken), { message: 'The type must be "JWT".' })
 })
 
+test('header must be a JSON object', t => {
+  // null header
+  const nullHeaderToken = `${Buffer.from('null').toString('base64url')}.${Buffer.from('{"sub":"test"}').toString('base64url')}.x`
+  t.assert.throws(() => defaultDecoder(nullHeaderToken), {
+    message: 'The token header is not a valid JSON object.'
+  })
+
+  // array header
+  const arrayHeaderToken = `${Buffer.from('[]').toString('base64url')}.${Buffer.from('{"sub":"test"}').toString('base64url')}.x`
+  t.assert.throws(() => defaultDecoder(arrayHeaderToken), {
+    message: 'The token header is not a valid JSON object.'
+  })
+
+  // string header
+  const stringHeaderToken = `${Buffer.from('"foo"').toString('base64url')}.${Buffer.from('{"sub":"test"}').toString('base64url')}.x`
+  t.assert.throws(() => defaultDecoder(stringHeaderToken), {
+    message: 'The token header is not a valid JSON object.'
+  })
+})
+
 test('invalid payload', t => {
   t.assert.throws(() => defaultDecoder('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.bbb.ccc'), {
     message: 'The token payload is not a valid base64url serialized JSON.'

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -545,6 +545,14 @@ test('payload validation', async t => {
   t.assert.rejects(async () => createSigner({ key: () => 'secret' })(123), {
     message: 'The payload must be an object.'
   })
+
+  t.assert.throws(() => createSigner({ key: 'secret' })(null), {
+    message: 'The payload must be an object.'
+  })
+
+  t.assert.rejects(async () => createSigner({ key: () => 'secret' })(null), {
+    message: 'The payload must be an object.'
+  })
 })
 
 test('exp claim validation', async t => {

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1110,6 +1110,23 @@ test('token type validation', t => {
   t.assert.throws(() => createVerifier({ key: 'secret' })(123), {
     message: 'The token must be a string or a buffer.'
   })
+
+  t.assert.throws(() => createVerifier({ key: 'secret', cache: true })(null), {
+    message: 'The token must be a string or a buffer.'
+  })
+})
+
+test('token type validation - async', async t => {
+  await t.assert.rejects(async () => createVerifier({ key: async () => 'secret', cache: true })(null), {
+    message: 'The token must be a string or a buffer.'
+  })
+})
+
+test('null header token', t => {
+  const nullHeaderToken = `${Buffer.from('null').toString('base64url')}.${Buffer.from('{"sub":"test"}').toString('base64url')}.x`
+  t.assert.throws(() => createVerifier({ key: 'secret' })(nullHeaderToken), {
+    message: 'The token header is not a valid JSON object.'
+  })
 })
 
 test('options validation - key', t => {


### PR DESCRIPTION
fixes #601

Guard against null in signer payload validation, decoder header validation, and verifier token type check before cache lookup.