### PR TITLE
fix: strict base64url validation on verify (#606)

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -2,6 +2,13 @@
 
 const { TokenError } = require('./error')
 
+// RFC 4648 §3.3 requires implementations to reject encoded data containing
+// characters outside the base alphabet unless the referring spec opts into
+// lenient decoding. RFC 7515 does not, so whitespace, newlines, and base64
+// padding in any of a JWT's three segments are a spec violation and should
+// not be silently stripped by `Buffer.from(segment, 'base64')`.
+const BASE64URL_RE = /^[A-Za-z0-9_-]*$/
+
 function decode({ complete, checkTyp }, token) {
   // Make sure the token is a string or a Buffer - Other cases make no sense to even try to validate
   if (token instanceof Buffer) {
@@ -18,10 +25,27 @@ function decode({ complete, checkTyp }, token) {
     throw new TokenError(TokenError.codes.malformed, 'The token is malformed.')
   }
 
+  const headerSegment = token.slice(0, firstSeparator)
+  const payloadSegment = token.slice(firstSeparator + 1, lastSeparator)
+  const signatureSegment = token.slice(lastSeparator + 1)
+
+  // Reject any segment containing characters outside the base64url alphabet
+  // before handing it to `Buffer.from(..., 'base64')`, which would otherwise
+  // silently strip them and accept a non-canonical token.
+  if (!BASE64URL_RE.test(headerSegment)) {
+    throw new TokenError(TokenError.codes.malformed, 'The token header is not a valid base64url serialized JSON.')
+  }
+  if (!BASE64URL_RE.test(payloadSegment)) {
+    throw new TokenError(TokenError.codes.malformed, 'The token payload is not a valid base64url serialized JSON.')
+  }
+  if (!BASE64URL_RE.test(signatureSegment)) {
+    throw new TokenError(TokenError.codes.invalidSignature, 'The token signature is invalid.')
+  }
+
   // Parse header
   let validHeader = false
   try {
-    const header = JSON.parse(Buffer.from(token.slice(0, firstSeparator), 'base64').toString('utf-8'))
+    const header = JSON.parse(Buffer.from(headerSegment, 'base64').toString('utf-8'))
     if (!header || typeof header !== 'object' || Array.isArray(header)) {
       throw new TokenError(TokenError.codes.malformed, 'The token header is not a valid JSON object.')
     }
@@ -31,7 +55,7 @@ function decode({ complete, checkTyp }, token) {
     validHeader = true
 
     // Parse payload
-    let payload = Buffer.from(token.slice(firstSeparator + 1, lastSeparator), 'base64').toString('utf-8')
+    let payload = Buffer.from(payloadSegment, 'base64').toString('utf-8')
     payload = JSON.parse(payload)
     // https://tools.ietf.org/html/rfc7519#section-7.2
     //
@@ -43,9 +67,7 @@ function decode({ complete, checkTyp }, token) {
     }
 
     // Return whatever was requested
-    return complete
-      ? { header, payload, signature: token.slice(lastSeparator + 1), input: token.slice(0, lastSeparator) }
-      : payload
+    return complete ? { header, payload, signature: signatureSegment, input: token.slice(0, lastSeparator) } : payload
   } catch (e) {
     throw TokenError.wrap(
       e,

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -152,13 +152,6 @@ function handleCachedResult(cached, callback, promise) {
   return promise
 }
 
-// RFC 4648 §3.3 requires implementations to reject encoded data containing
-// characters outside the base alphabet unless the referring spec opts into
-// lenient decoding. RFC 7515 does not, so whitespace and other non-alphabet
-// characters in the signature segment of a JWT are a spec violation and
-// should not be silently stripped by `Buffer.from(sig, 'base64')`.
-const BASE64URL_RE = /^[A-Za-z0-9_-]*$/
-
 function validateAlgorithmAndSignature(input, header, signature, key, allowedAlgorithms) {
   // According to the signature and key, check with algorithms are supported
   // Verify the token is allowed
@@ -166,14 +159,9 @@ function validateAlgorithmAndSignature(input, header, signature, key, allowedAlg
     throw new TokenError(TokenError.codes.invalidAlgorithm, 'The token algorithm is invalid.')
   }
 
-  // Reject signatures containing characters outside the base64url alphabet
-  // (e.g. whitespace, newlines) before handing them to the crypto decoder,
-  // which would otherwise silently strip them and accept the token.
-  if (signature && !BASE64URL_RE.test(signature)) {
-    throw new TokenError(TokenError.codes.invalidSignature, 'The token signature is invalid.')
-  }
-
-  // Verify the signature, if present
+  // Verify the signature, if present. The decoder has already rejected tokens
+  // whose segments contain characters outside the base64url alphabet, so by
+  // the time we get here `signature` is either empty or canonical.
   if (signature && !verifySignature(header.alg, key, input, signature)) {
     throw new TokenError(TokenError.codes.invalidSignature, 'The token signature is invalid.')
   }

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -152,11 +152,25 @@ function handleCachedResult(cached, callback, promise) {
   return promise
 }
 
+// RFC 4648 §3.3 requires implementations to reject encoded data containing
+// characters outside the base alphabet unless the referring spec opts into
+// lenient decoding. RFC 7515 does not, so whitespace and other non-alphabet
+// characters in the signature segment of a JWT are a spec violation and
+// should not be silently stripped by `Buffer.from(sig, 'base64')`.
+const BASE64URL_RE = /^[A-Za-z0-9_-]*$/
+
 function validateAlgorithmAndSignature(input, header, signature, key, allowedAlgorithms) {
   // According to the signature and key, check with algorithms are supported
   // Verify the token is allowed
   if (!allowedAlgorithms.includes(header.alg)) {
     throw new TokenError(TokenError.codes.invalidAlgorithm, 'The token algorithm is invalid.')
+  }
+
+  // Reject signatures containing characters outside the base64url alphabet
+  // (e.g. whitespace, newlines) before handing them to the crypto decoder,
+  // which would otherwise silently strip them and accept the token.
+  if (signature && !BASE64URL_RE.test(signature)) {
+    throw new TokenError(TokenError.codes.invalidSignature, 'The token signature is invalid.')
   }
 
   // Verify the signature, if present

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -104,3 +104,54 @@ test('payload must be a JSON object', t => {
     }
   )
 })
+
+// https://datatracker.ietf.org/doc/html/rfc4648#section-3.3 - strict base64url
+// alphabet for every segment of a JWT. These tests cover the per-segment
+// rejection path in decode() so callers of decode() (not just verify()) see
+// canonical-segment tokens.
+test('rejects header segment with non-base64url characters', t => {
+  const base = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+  const [header, rest] = [base, 'eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM']
+
+  for (const bad of [' ' + header, header + ' ', header + '\n', header + '=']) {
+    t.assert.throws(
+      () => defaultDecoder(`${bad}.${rest}`),
+      { message: 'The token header is not a valid base64url serialized JSON.' },
+      `expected rejection for header: ${JSON.stringify(bad)}`
+    )
+  }
+})
+
+test('rejects payload segment with non-base64url characters', t => {
+  const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+  const payload = 'eyJhIjoxfQ'
+  const sig = '57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM'
+
+  for (const bad of [payload + ' ', ' ' + payload, payload + '\n', payload + '=']) {
+    t.assert.throws(
+      () => defaultDecoder(`${header}.${bad}.${sig}`),
+      { message: 'The token payload is not a valid base64url serialized JSON.' },
+      `expected rejection for payload: ${JSON.stringify(bad)}`
+    )
+  }
+})
+
+test('rejects signature segment with non-base64url characters', t => {
+  const base = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ'
+  const sig = '57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM'
+
+  for (const bad of [
+    sig + ' ',
+    sig + '\n',
+    sig + '\r\n',
+    sig + '\t',
+    sig + '=',
+    sig.slice(0, -10) + ' ' + sig.slice(-10)
+  ]) {
+    t.assert.throws(
+      () => defaultDecoder(`${base}.${bad}`),
+      { message: 'The token signature is invalid.' },
+      `expected rejection for signature: ${JSON.stringify(bad)}`
+    )
+  }
+})

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -207,6 +207,35 @@ test('it rejects invalid tokens', async t => {
   )
 })
 
+test('it rejects tokens with non-base64url characters in the signature segment', t => {
+  // Canonical HS256 token signed with key 'secret' over payload {"a":1}
+  const base = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM'
+
+  // RFC 4648 §3.3 requires implementations to reject data outside the base
+  // alphabet. Each of these embeds whitespace, newlines, or padding in the
+  // signature segment.
+  const nonCanonical = [
+    base + ' ',
+    base + '\t',
+    base + '\n',
+    base + '\r\n',
+    base.slice(0, -10) + ' ' + base.slice(-10),
+    base.slice(0, -10) + '\t' + base.slice(-10),
+    base + '='
+  ]
+
+  for (const token of nonCanonical) {
+    t.assert.throws(
+      () => verify(token, {}),
+      { message: 'The token signature is invalid.' },
+      `expected rejection for token with non-base64url chars: ${JSON.stringify(token)}`
+    )
+  }
+
+  // Canonical token is still accepted for comparison
+  t.assert.deepStrictEqual(verify(base, {}), { a: 1 })
+})
+
 test('it requires a signature or a key', async t => {
   t.assert.throws(() => verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.', {}), {
     message: 'The token signature is missing.'


### PR DESCRIPTION
Closes #606.

## Problem

\`verify()\` accepted tokens whose signature segment contained whitespace, newlines, or base64 padding because \`Buffer.from(sig, 'base64')\` silently strips those characters before comparing the decoded bytes. This deviates from RFC 4648 §3.3, which requires implementations to reject encoded data containing characters outside the base alphabet. RFC 7515 does not opt into lenient decoding.

## Fix

Add a strict base64url regex check (\`^[A-Za-z0-9_-]*\$\`) in \`validateAlgorithmAndSignature\` that runs before the signature is handed to the crypto decoder. Non-canonical tokens now throw \`invalidSignature\`.

## Test

Added a test case in \`test/verifier.spec.js\` covering the variants the issue enumerates:

- trailing space, tab, LF, CRLF
- whitespace in the middle of the signature segment
- base64 padding (\`=\`)

Ran \`npm test\` — 281 tests pass, 0 fail. \`npm run lint\` — clean.

## Notes

The check is scoped to the signature segment only (via \`validateAlgorithmAndSignature\`), consistent with the issue title. I did not touch header/payload decoding since the issue is explicit about verify. Happy to extend the check to those segments in a follow-up if you'd prefer; it would be a one-line change at each decode call in \`src/decoder.js\`.