### PR TITLE
refactor(types): migrate from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint .",
-    "test": "node --test --experimental-test-coverage test/*.spec.js && tstyche",
+    "test": "node --test --experimental-test-coverage test/**.spec.js && tstyche",
     "test:ci": "npm run lint && npm run test",
     "test:watch": "node --test --watch --experimental-test-coverage",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint .",
     "test": "node --test --experimental-test-coverage test/**/*.spec.js",
     "test:typescript": "tstyche",
-    "test:ci": "npm run lint && npm run test",
+    "test:ci": "npm run lint && npm run test && npm run test:typescript",
     "test:watch": "node --test --watch --experimental-test-coverage",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",
     "test:generate-tokens": "node benchmarks/keys/generate-tokens.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint .",
-    "test": "node --test --experimental-test-coverage test/**/*.spec.js && tstyche",
+    "test": "node --test --experimental-test-coverage test/*.spec.js && tstyche",
     "test:ci": "npm run lint && npm run test",
     "test:watch": "node --test --watch --experimental-test-coverage",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
   "scripts": {
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint .",
-    "test": "node --test --experimental-test-coverage test/**/*.spec.js",
-    "test:typescript": "tstyche",
-    "test:ci": "npm run lint && npm run test && npm run test:typescript",
+    "test": "node --test --experimental-test-coverage test/**/*.spec.js && tstyche",
+    "test:ci": "npm run lint && npm run test",
     "test:watch": "node --test --watch --experimental-test-coverage",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",
     "test:generate-tokens": "node benchmarks/keys/generate-tokens.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "postpublish": "git push origin && git push origin -f --tags",
     "lint": "eslint .",
-    "test": "node --test --experimental-test-coverage test/**.spec.js && tsd",
+    "test": "node --test --experimental-test-coverage test/**/*.spec.js",
+    "test:typescript": "tstyche",
     "test:ci": "npm run lint && npm run test",
     "test:watch": "node --test --watch --experimental-test-coverage",
     "test:generate-keys": "node benchmarks/keys/generate-keys.js",
@@ -72,14 +73,11 @@
     "jsonwebtoken": "^9.0.2",
     "mitata": "^1.0.34",
     "prettier": "^3.4.2",
-    "tsd": "^0.33.0",
+    "tstyche": "^7.1.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.18.0"
   },
   "engines": {
     "node": ">=20"
-  },
-  "tsd": {
-    "directory": "test"
   }
 }

--- a/test/types.tst.ts
+++ b/test/types.tst.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
+import { expect } from 'tstyche'
 import {
   createDecoder,
   createSigner,
@@ -105,17 +105,17 @@ createVerifier<Record<string, number>>({
 
 // Errors
 const errorWithNoMsg = new TokenError(TokenError.codes.expired)
-expectType<TokenError>(errorWithNoMsg)
-expectType<string>(errorWithNoMsg.message)
+expect(errorWithNoMsg).type.toBe<TokenError>()
+expect(errorWithNoMsg.message).type.toBe<string>()
 
 const errorWithMsg = new TokenError(TokenError.codes.expired, 'MESSAGE')
-expectType<TokenError>(errorWithMsg)
-expectType<string>(errorWithMsg.message)
+expect(errorWithMsg).type.toBe<TokenError>()
+expect(errorWithMsg.message).type.toBe<string>()
 
 const errorWithAdditional = new TokenError(TokenError.codes.expired, 'MESSAGE', { additional: 'data' })
-expectType<TokenError>(errorWithAdditional)
-expectType<string>(errorWithAdditional.message)
-expectType<any>(errorWithAdditional.additional)
+expect(errorWithAdditional).type.toBe<TokenError>()
+expect(errorWithAdditional.message).type.toBe<string>()
+expect(errorWithAdditional.additional).type.toBe<any>()
 
 const wrapped = TokenError.wrap(new Error('ORIGINAL'), 'FAST_JWT_INVALID_TYPE', 'MESSAGE')
 wrapped.code === 'FAST_JWT_INVALID_TYPE'
@@ -137,7 +137,7 @@ const signerOptions = {
     x5c: ''
   }
 }
-expectAssignable<JwtHeader>(signerOptions.header)
+expect(signerOptions.header).type.toBeAssignableTo<JwtHeader>()
 
 const signerOptionsCustomHeaders = {
   header: {
@@ -155,7 +155,7 @@ const signerOptionsCustomHeaders = {
     customClaim2: 'my-custom-claim2'
   }
 }
-expectAssignable<JwtHeader>(signerOptionsCustomHeaders.header)
+expect(signerOptionsCustomHeaders.header).type.toBeAssignableTo<JwtHeader>()
 
 const signerOptionsNoAlg = {
   header: {
@@ -170,19 +170,19 @@ const signerOptionsNoAlg = {
     x5c: ''
   }
 }
-expectNotAssignable<JwtHeader>(signerOptionsNoAlg.header)
+expect(signerOptionsNoAlg.header).type.not.toBeAssignableTo<JwtHeader>()
 
 // Check object and class static matches their own type
-expectType<typeof TOKEN_ERROR_CODES>(TOKEN_ERROR_CODES)
-expectType<typeof TOKEN_ERROR_CODES>(TokenError.codes)
+expect(TOKEN_ERROR_CODES).type.toBe<typeof TOKEN_ERROR_CODES>()
+expect(TokenError.codes).type.toBe<typeof TOKEN_ERROR_CODES>()
 
 // Check all enum values are assignable to TokenValidationErrorCode union
-expectType<TokenValidationErrorCode[]>(Object.values(TOKEN_ERROR_CODES))
-expectType<TokenValidationErrorCode[]>(Object.values(TokenError.codes))
+expect(Object.values(TOKEN_ERROR_CODES)).type.toBe<TokenValidationErrorCode[]>()
+expect(Object.values(TokenError.codes)).type.toBe<TokenValidationErrorCode[]>()
 
 // Check enums resolve to correct string literals
 const code: TokenValidationErrorCode = TOKEN_ERROR_CODES.expired
-expectType<"FAST_JWT_EXPIRED">(code)
+expect(code).type.toBe<"FAST_JWT_EXPIRED">()
 
 const decodedJwt: DecodedJwt = {
   header: { alg: 'RS256', typ: 'JWT' },
@@ -191,8 +191,8 @@ const decodedJwt: DecodedJwt = {
   input: 'input'
 }
 
-expectType<DecodedJwt>(decodedJwt)
-expectType<Record<string, any>>(decodedJwt.header)
-expectType<any>(decodedJwt.payload)
-expectType<string>(decodedJwt.signature)
-expectType<string>(decodedJwt.input)
+expect(decodedJwt).type.toBe<DecodedJwt>()
+expect(decodedJwt.header).type.toBe<Record<string, any>>()
+expect(decodedJwt.payload).type.toBe<any>()
+expect(decodedJwt.signature).type.toBe<string>()
+expect(decodedJwt.input).type.toBe<string>()

--- a/test/types.tst.ts
+++ b/test/types.tst.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-expressions */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/// <reference types="node" />
 
 import { expect } from 'tstyche'
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
-    "module": "commonjs",
     "moduleResolution": "node",
-    "jsx": "preserve",
-    "outDir": "lib",
-    "declarationDir": "types",
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strictNullChecks": true,
-    "declaration": true
+    "ignoreDeprecations": "6.0",
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": []
+  "include": ["test/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
-    "types": ["node"]
-  },
-  "include": ["test/**/*.ts"]
-}


### PR DESCRIPTION
Migrates type tests from `tsd` to `tstyche`.

References:
- https://github.com/fastify/fastify/pull/6532
- https://github.com/fastify/fastify/pull/6525