### PR TITLE
fix: update exp and nbf claim handling in sing function

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -94,8 +94,18 @@ function sign(
     ...payload,
     ...fixedPayload,
     iat: noTimestamp ? undefined : Math.floor(iat / 1000),
-    exp: expiresIn != null ? Math.floor((iat + expiresIn) / 1000) : payload.exp ? payload.exp : undefined,
-    nbf: notBefore != null ? Math.floor((iat + notBefore) / 1000) : payload.nbf ? payload.nbf : undefined
+    exp:
+      expiresIn != null && Number.isFinite(expiresIn)
+        ? Math.floor((iat + expiresIn) / 1000)
+        : payload.exp
+          ? payload.exp
+          : undefined,
+    nbf:
+      notBefore != null && Number.isFinite(notBefore)
+        ? Math.floor((iat + notBefore) / 1000)
+        : payload.nbf
+          ? payload.nbf
+          : undefined
   }
 
   if (mutatePayload) {

--- a/src/signer.js
+++ b/src/signer.js
@@ -94,8 +94,8 @@ function sign(
     ...payload,
     ...fixedPayload,
     iat: noTimestamp ? undefined : Math.floor(iat / 1000),
-    exp: payload.exp ? payload.exp : expiresIn ? Math.floor((iat + expiresIn) / 1000) : undefined,
-    nbf: payload.nbf ? payload.nbf : notBefore ? Math.floor((iat + notBefore) / 1000) : undefined
+    exp: expiresIn != null ? Math.floor((iat + expiresIn) / 1000) : payload.exp ? payload.exp : undefined,
+    nbf: notBefore != null ? Math.floor((iat + notBefore) / 1000) : payload.nbf ? payload.nbf : undefined
   }
 
   if (mutatePayload) {

--- a/test/signer.spec.js
+++ b/test/signer.spec.js
@@ -273,7 +273,7 @@ test('it uses the clockTimestamp option, if one is set', async t => {
   )
 })
 
-test('it respects payload exp claim (if supplied), overriding the default expiresIn timeout', async t => {
+test('it adds exp from expiresIn, overriding an existing payload exp claim', async t => {
   t.assert.equal(
     sign({ a: 1, iat: 100 }, { expiresIn: 1000 }),
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoxMDF9.ULKqTsvUYm7iNOKA6bP5NXsa1A8vofgPIGiC182Vf_Q'
@@ -281,7 +281,7 @@ test('it respects payload exp claim (if supplied), overriding the default expire
 
   t.assert.equal(
     sign({ a: 1, iat: 100, exp: 200 }, { expiresIn: 1000 }),
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoyMDB9.RJbB3-VIjLIQr-VmZ1Kl42MrHr2pAU-CQuXK8jHMKR0'
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoxMDF9.ULKqTsvUYm7iNOKA6bP5NXsa1A8vofgPIGiC182Vf_Q'
   )
 })
 
@@ -328,17 +328,15 @@ test('it ignores invalid exp claim', async t => {
   )
 })
 
-test('it adds a nbf claim, overriding the payload one, only if the payload is a object', async t => {
+test('it adds nbf from notBefore, overriding an existing payload nbf claim', async t => {
   t.assert.equal(
     sign({ a: 1, iat: 100 }, { notBefore: 1000 }),
-    // jwt that contains nbf claim to be 1000
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwibmJmIjoxMDF9.WhZeNowse7q1s5FSlcMcs_4KcxXpSdQ4yqv0xrGB3sU'
   )
 
   t.assert.equal(
     sign({ a: 1, iat: 100, nbf: 200 }, { notBefore: 1000 }),
-    // jwt that contains nbf claim to be 200
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwibmJmIjoyMDB9.HmHmbH-pOTlpj5FsVN61aT2PFhd6EN-tnQdExv_HUs4'
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwibmJmIjoxMDF9.WhZeNowse7q1s5FSlcMcs_4KcxXpSdQ4yqv0xrGB3sU'
   )
 })
 
@@ -435,6 +433,17 @@ test('it adds additional arbitrary fields to the header', async t => {
 
 test('it mutates the payload if asked to', async t => {
   const payload = { a: 1, iat: 100 }
+
+  t.assert.equal(
+    sign(payload, { mutatePayload: true, expiresIn: 1000 }),
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJpYXQiOjEwMCwiZXhwIjoxMDF9.ULKqTsvUYm7iNOKA6bP5NXsa1A8vofgPIGiC182Vf_Q'
+  )
+
+  t.assert.equal(payload.exp, 101)
+})
+
+test('it mutates the payload with the computed exp when expiresIn overrides an existing payload exp claim', async t => {
+  const payload = { a: 1, iat: 100, exp: 200 }
 
   t.assert.equal(
     sign(payload, { mutatePayload: true, expiresIn: 1000 }),


### PR DESCRIPTION
This fixes a mismatch between the README and the signer: `expiresIn` and `notBefore` are documented to override existing `exp` / `nbf` on the payload, but the implementation kept payload values when both were set.

**What changed**
In src/signer.js, precedence for exp and nbf now matches the docs (and the same behaviour as iss, aud, jti, etc.):

- If `expiresIn` / `notBefore` is set on the signer → use the computed claim
- Otherwise → use `payload.exp` / `payload.nbf` when present 


If someone relied on payload `exp` / `nbf` winning when both the signer option and the payload claim were set, token expiry / not-before will change after this fix. That behaviour matched the old code, not the README.

Fixes #570 
