### PR TITLE
fix: skip public key detection for HSxxx algorithms

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -71,8 +71,14 @@ function cacheSet(cache, key, value, error) {
   return value || error
 }
 
-function performDetectPrivateKeyAlgorithm(key) {
+function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const trimmedKey = key.trim()
+
+  if (hsAlgorithms.includes(providedAlgorithm)) {
+    // the key string might look like a public/private key, but it should be used as a raw string
+    return providedAlgorithm
+  }
+
   if (trimmedKey.match(publicKeyPemMatcher) || trimmedKey.includes(publicKeyX509CertMatcher)) {
     throw new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
   }
@@ -188,7 +194,7 @@ function detectPrivateKeyAlgorithm(key, providedAlgorithm) {
 
   // Try detecting
   try {
-    const detectedAlgorithm = performDetectPrivateKeyAlgorithm(key)
+    const detectedAlgorithm = performDetectPrivateKeyAlgorithm(key, providedAlgorithm)
 
     if (detectedAlgorithm === 'ENCRYPTED') {
       return cacheSet(privateKeysCache, key, providedAlgorithm)
@@ -204,10 +210,17 @@ function detectPrivateKeyAlgorithm(key, providedAlgorithm) {
   }
 }
 
-function detectPublicKeyAlgorithms(key) {
+function detectPublicKeyAlgorithms(key, providedAlgorithms) {
   if (!key) {
     return 'none'
   }
+
+  // If all provided algorithms are HS, skip detection and caching entirely
+  // since the key might look like a PEM but should be used as a raw HMAC secret
+  if (providedAlgorithms && providedAlgorithms.length && providedAlgorithms.every(a => hsAlgorithms.includes(a))) {
+    return providedAlgorithms
+  }
+
   // Check cache first
   const [cached, error] = publicKeysCache.get(key) || []
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -513,7 +513,7 @@ module.exports = function createVerifier(options) {
 
   if (key && keyType !== 'function') {
     // Detect the private key - If the algorithms were known, just verify they match, otherwise assign them
-    const availableAlgorithms = detectPublicKeyAlgorithms(key)
+    const availableAlgorithms = detectPublicKeyAlgorithms(key, allowedAlgorithms)
 
     if (allowedAlgorithms.length) {
       checkAreCompatibleAlgorithms(allowedAlgorithms, availableAlgorithms)
@@ -521,7 +521,7 @@ module.exports = function createVerifier(options) {
       allowedAlgorithms = availableAlgorithms
     }
 
-    key = prepareKeyOrSecret(key, availableAlgorithms[0] === hsAlgorithms[0])
+    key = prepareKeyOrSecret(key, hsAlgorithms.includes(availableAlgorithms[0]))
   }
 
   if (clockTimestamp && (typeof clockTimestamp !== 'number' || clockTimestamp < 0)) {

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -145,6 +145,12 @@ test('detectPrivateKeyAlgorithm - public keys should be rejected', t => {
   })
 })
 
+test('detectPrivateKeyAlgorithm - public keys should be accepted if HS256, HS384, HS512 is used', t => {
+  ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
+    t.assert.equal(detectPrivateKeyAlgorithm(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, algorithm), algorithm)
+  })
+})
+
 test('detectPrivateKeyAlgorithm - unrecognized PKCS8 OIDs should be rejected', t => {
   t.assert.throws(() => detectPrivateKeyAlgorithm(invalidPrivatePKCS8), {
     message: 'Unsupported PEM PCKS8 private key with OID 1.2.840.10040.4.1.'
@@ -219,6 +225,15 @@ test('detectPublicKeyAlgorithms - private keys should be rejected', t => {
   })
 })
 
+test('detectPublicKeyAlgorithms - public key-like strings should be accepted if all provided algorithms are HS', t => {
+  ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
+    t.assert.deepStrictEqual(
+      detectPublicKeyAlgorithms(`-----BEGIN PUBLIC KEY-----\nUSED IN ${algorithm}`, [algorithm]),
+      [algorithm]
+    )
+  })
+})
+
 test('detectPublicKeyAlgorithms - unrecognized PKCS8 OIDs should be rejected', t => {
   t.assert.throws(() => detectPublicKeyAlgorithms(invalidPublicPKCS8), {
     message: 'Unsupported PEM PCKS8 public key with OID 1.2.840.10040.4.1.'
@@ -286,12 +301,12 @@ test('detectPrivateKeyAlgorithm - EC private key with leading whitespace must st
 
 for (const bits of [256, 384, 512]) {
   const hsAlgorithm = `HS${bits}`
+  const key = privateKeys.HS
 
-  // HS256, HS512, HS512
+  // HS256, HS384, HS512
   test(`${hsAlgorithm} based tokens round trip with string keys`, t => {
-    const token = createSigner({ algorithm: hsAlgorithm, key: 'secretsecretsecret' })({ payload: 'PAYLOAD' })
-
-    const verified = createVerifier({ key: 'secretsecretsecret' })(token)
+    const token = createSigner({ algorithm: hsAlgorithm, key })({ payload: 'PAYLOAD' })
+    const verified = createVerifier({ key })(token)
 
     t.assert.equal(verified.payload, 'PAYLOAD')
     t.assert.ok(verified.iat >= start)
@@ -299,11 +314,8 @@ for (const bits of [256, 384, 512]) {
   })
 
   test(`${hsAlgorithm} based tokens round trip with buffer keys`, t => {
-    const token = createSigner({ algorithm: hsAlgorithm, key: Buffer.from('secretsecretsecret', 'utf-8') })({
-      payload: 'PAYLOAD'
-    })
-
-    const verified = createVerifier({ key: 'secretsecretsecret' })(token)
+    const token = createSigner({ algorithm: hsAlgorithm, key: Buffer.from(key, 'utf-8') })({ payload: 'PAYLOAD' })
+    const verified = createVerifier({ key })(token)
 
     t.assert.equal(verified.payload, 'PAYLOAD')
     t.assert.ok(verified.iat >= start)
@@ -314,6 +326,16 @@ for (const bits of [256, 384, 512]) {
     await t.assert.rejects(createSigner({ algorithm: hsAlgorithm, key: async () => 123 })({ payload: 'PAYLOAD' }), {
       message: 'The key returned from the callback must be a string or a buffer containing a secret or a private key.'
     })
+  })
+
+  const pemLikeSecret = `-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo\n4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u\n-----END PUBLIC KEY-----`
+  test(`${hsAlgorithm} based tokens round trip with PEM-like secret keys`, t => {
+    const token = createSigner({ algorithm: hsAlgorithm, key: pemLikeSecret })({ payload: 'PAYLOAD' })
+    const verified = createVerifier({ algorithms: [hsAlgorithm], key: pemLikeSecret })(token)
+
+    t.assert.equal(verified.payload, 'PAYLOAD')
+    t.assert.ok(verified.iat >= start)
+    t.assert.ok(verified.iat <= Date.now() / 1000)
   })
 }
 


### PR DESCRIPTION
### Problem
When an HMAC secret happens to look like a PEM key (e.g. a string starting with `-----BEGIN PUBLIC KEY-----`), fast-jwt's key-detection logic misidentified it as an actual public key.

This caused signing to fail with `Public keys are not supported for signing.` and verification to treat the secret as an asymmetric key — even when the user explicitly requested an `HS256`/`HS384`/`HS512` algorithm.

See: https://github.com/nearform/fast-jwt/pull/576

### Solution
When the algorithm is explicitly provided and is HMAC-based, skip PEM detection entirely and use the key as a raw secret:

- **`detectPrivateKeyAlgorithm`** (signing): returns the provided algorithm immediately when it's an HSxxx algorithm, bypassing public-key rejection.
- **`detectPublicKeyAlgorithms`** (verifying): skips detection and caching when all provided algorithms are HSxxx.
- **`verifier.js`**: passes the allowed algorithms down to detection, and fixes the secret-vs-key check to match any HS algorithm rather than only `HS256`.

### Testing
- New unit tests covering PEM-like strings accepted for HS256/HS384/HS512 in both private and public key detection.
- New round-trip sign/verify tests using a PEM-like secret for each HS algorithm.

###  Supersedes:
- https://github.com/nearform/fast-jwt/pull/576
- https://github.com/JChopraNearform/fast-jwt/tree/fix/verify-pem-like-hs-keys