### PR TITLE
chore(deps): bump eslint to 10 and related tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,22 +59,22 @@
     "safe-regex2": "^5.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@node-rs/jsonwebtoken": "^0.5.9",
     "@types/node": "^26.0.0",
-    "eslint": "^9.17.0",
-    "eslint-config-prettier": "^10.0.1",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-n": "^18.0.1",
-    "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-promise": "^7.2.1",
+    "eslint": "^10.7.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.6",
     "fastify": "^5.2.0",
+    "globals": "^17.7.0",
+    "jiti": "^2.7.0",
     "jose": "^2.0.7",
     "jsonwebtoken": "^9.0.2",
     "mitata": "^1.0.34",
     "prettier": "^3.4.2",
     "tstyche": "^7.1.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.18.0"
+    "typescript-eslint": "^8.65.0"
   },
   "engines": {
     "node": ">=20"

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ function ensurePromiseCallback(callback) {
 function hashToken(token) {
   const rawHeader = token.split('.', 1)[0]
   const header = Buffer.from(rawHeader, 'base64').toString('utf-8')
-  let hasher = null
+  let hasher
 
   /* istanbul ignore next */
   if (header.match(edAlgorithmMatcher) && header.match(ed448CurveMatcher)) {


### PR DESCRIPTION
Closes #633

## What

Bumps ESLint to v10 and aligns the lint toolchain. Part of the dependency work tracked alongside #630.

### package.json
- `eslint` `^9.17.0` → `^10.7.0`
- `typescript-eslint` `^8.18.0` → `^8.65.0` (declares `eslint ^10` peer support)
- `eslint-config-prettier` `^10.0.1` → `^10.1.8` — required because `eslint-plugin-prettier`'s peer range excludes `>=10.0.0 <10.1.0`
- `eslint-plugin-prettier` `^5.2.1` → `^5.5.6`
- **Added** `@eslint/js@^10.0.1` and `globals@^17.7.0` — no longer resolved transitively under ESLint 10, and both are imported by `eslint.config.js`
- **Added** `jiti@^2.7.0` — new peer dependency of `eslint@10`
- **Removed** unused `eslint-plugin-import` / `eslint-plugin-n` / `eslint-plugin-promise` (none referenced in `eslint.config.js`; `eslint-plugin-import` has no ESLint-10-compatible release)

### src/utils.js
- `let hasher = null` → `let hasher` in `hashToken()` to satisfy ESLint 10's new `no-useless-assignment` rule. The initializer was dead — both the `if` and `else` branches reassign `hasher` before it is read.

## TypeScript 7 deferred (intentional)

The companion request was to also bump `typescript` to `7.0.2`. That is **held back** because the TS-7 native (Go) port isn't yet supported by this project's TS tooling:

- **typescript-eslint** throws `does not support TS 7.0` at config load; per typescript-eslint/typescript-eslint#10940 support is ~1-2 major versions away.
- **tstyche** (the type-test runner) caps at TS `6.0.3`; `--target 7.0.2` errors and it otherwise silently falls back to `6.0.3`.

Bumping now would remove TS-aware linting and silently stop testing types against the intended version, for no real gain. `typescript` stays at `^6.0.3`; revisit when the tooling lands TS 7 support.

## Verification

- `npm install` — resolves cleanly, 0 vulnerabilities
- `npm run lint` — clean
- `npx tstyche` — 20/20 assertions pass (TypeScript 6.0.3)
- `node --test test/**.spec.js` — full suite passes
- `npm run test:ci` — passes end-to-end

No CI/engines change needed: CI's `.nvmrc = lts/*` already satisfies ESLint 10's Node `>=20.19` requirement, and `engines.node` governs consumers, not the dev toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)