### PR TITLE
fix: reject non-whitespace key prefixes to close RSA→HS256 algorithm confusion (GHSA-ww5h-9m49-7xx4)

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -27,6 +27,14 @@ const encoderMap = { '=': '', '+': '-', '/': '_' }
 const privateKeyPemMatcher = /^-----BEGIN(?: (RSA|EC|ENCRYPTED))? PRIVATE KEY-----/
 const publicKeyPemMatcher = /^-----BEGIN(?: (RSA))? PUBLIC KEY-----/
 const publicKeyX509CertMatcher = '-----BEGIN CERTIFICATE-----'
+// Matches any PEM/certificate header regardless of its position in the string.
+// Used to locate the start of a PEM block so that leading bytes (whitespace,
+// control chars, zero-width unicode, comments, wrappers, ...) cannot push the
+// header off position 0 and defeat the ^-anchored matchers above, which would
+// misclassify an asymmetric key as an HMAC secret (algorithm confusion —
+// GHSA-ww5h-9m49-7xx4, the incomplete-fix lineage of CVE-2023-48223 /
+// CVE-2026-34950).
+const pemBeginMatcher = /-----BEGIN [A-Z0-9 ]+?-----/
 const privateKeysCache = new Cache(1000)
 const publicKeysCache = new Cache(1000)
 
@@ -79,14 +87,28 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
     return providedAlgorithm
   }
 
-  if (trimmedKey.match(publicKeyPemMatcher) || trimmedKey.includes(publicKeyX509CertMatcher)) {
+  // Locate the PEM block wherever it starts. If there is no PEM/certificate
+  // header at all, this is a genuine raw HMAC secret. If there is one, it must
+  // be classified as asymmetric key material below and can never fall back to
+  // being used as an HMAC secret.
+  const pemStart = trimmedKey.search(pemBeginMatcher)
+
+  if (pemStart === -1) {
+    return 'HS256'
+  }
+
+  const pem = trimmedKey.slice(pemStart)
+
+  if (pem.match(publicKeyPemMatcher) || pem.includes(publicKeyX509CertMatcher)) {
     throw new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
   }
 
-  const pemData = trimmedKey.match(privateKeyPemMatcher)
+  const pemData = pem.match(privateKeyPemMatcher)
 
   if (!pemData) {
-    return 'HS256'
+    // A PEM header is present but it is neither a supported private key nor a
+    // public key/certificate: refuse rather than silently using it as a secret.
+    throw new TokenError(TokenError.codes.invalidKey, 'Unsupported PEM private key.')
   }
 
   let keyData
@@ -97,14 +119,14 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
     case 'RSA': // pkcs1 format - Can only be RSA key
       return 'RS256'
     case 'EC': // sec1 format - Can only be a EC key
-      keyData = ECPrivateKey.decode(trimmedKey, 'pem', { label: 'EC PRIVATE KEY' })
+      keyData = ECPrivateKey.decode(pem, 'pem', { label: 'EC PRIVATE KEY' })
       curveId = keyData.parameters.value.join('.')
       break
     case 'ENCRYPTED': // Can be either RSA or EC key - we'll used the supplied algorithm
       return 'ENCRYPTED'
     default:
       // pkcs8
-      keyData = PrivateKey.decode(trimmedKey, 'pem', { label: 'PRIVATE KEY' })
+      keyData = PrivateKey.decode(pem, 'pem', { label: 'PRIVATE KEY' })
       oid = keyData.algorithm.algorithm.join('.')
 
       switch (oid) {
@@ -132,22 +154,32 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
 
 function performDetectPublicKeyAlgorithms(key) {
   const trimmedKey = key.trim()
-  const publicKeyPemMatch = trimmedKey.match(publicKeyPemMatcher)
 
-  if (trimmedKey.match(privateKeyPemMatcher)) {
-    throw new TokenError(TokenError.codes.invalidKey, 'Private keys are not supported for verifying.')
-  } else if (publicKeyPemMatch && publicKeyPemMatch[1] === 'RSA') {
-    // pkcs1 format - Can only be RSA key
-    return rsaAlgorithms
-  } else if (!publicKeyPemMatch && !trimmedKey.includes(publicKeyX509CertMatcher)) {
+  // Locate the PEM/certificate block wherever it starts. Only a key with no PEM
+  // header anywhere is treated as a raw HMAC secret; once a header is present it
+  // must be classified as asymmetric key material and can never fall back to
+  // HMAC, otherwise a public key would be usable as the HMAC shared secret.
+  const pemStart = trimmedKey.search(pemBeginMatcher)
+
+  if (pemStart === -1) {
     // Not a PEM, assume a plain secret
     return hsAlgorithms
   }
 
+  const pem = trimmedKey.slice(pemStart)
+  const publicKeyPemMatch = pem.match(publicKeyPemMatcher)
+
+  if (pem.match(privateKeyPemMatcher)) {
+    throw new TokenError(TokenError.codes.invalidKey, 'Private keys are not supported for verifying.')
+  } else if (publicKeyPemMatch && publicKeyPemMatch[1] === 'RSA') {
+    // pkcs1 format - Can only be RSA key
+    return rsaAlgorithms
+  }
+
   // if the key is a X509 cert we need to convert it
-  let resolvedKey = trimmedKey
-  if (trimmedKey.includes(publicKeyX509CertMatcher)) {
-    resolvedKey = createPublicKey(trimmedKey).export({ type: 'spki', format: 'pem' })
+  let resolvedKey = pem
+  if (pem.includes(publicKeyX509CertMatcher)) {
+    resolvedKey = createPublicKey(pem).export({ type: 'spki', format: 'pem' })
   }
 
   const keyData = PublicKey.decode(resolvedKey, 'pem', { label: 'PUBLIC KEY' })

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -79,6 +79,22 @@ function cacheSet(cache, key, value, error) {
   return value || error
 }
 
+// Single source of truth for locating a PEM/certificate block. Returns the key
+// sliced from its first `-----BEGIN ...-----` header, or flags it as a raw HMAC
+// secret when no header is present anywhere. Both detectors MUST use this and
+// classify by the leading header of the slice, so their handling can never
+// drift apart (the drift is how this CVE lineage stayed incomplete —
+// GHSA-ww5h-9m49-7xx4 / CVE-2026-34950 / CVE-2023-48223).
+function locatePem(trimmedKey) {
+  const pemStart = trimmedKey.search(pemBeginMatcher)
+
+  if (pemStart === -1) {
+    return { pem: null, isRawSecret: true }
+  }
+
+  return { pem: trimmedKey.slice(pemStart), isRawSecret: false }
+}
+
 function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const trimmedKey = key.trim()
 
@@ -87,19 +103,13 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
     return providedAlgorithm
   }
 
-  // Locate the PEM block wherever it starts. If there is no PEM/certificate
-  // header at all, this is a genuine raw HMAC secret. If there is one, it must
-  // be classified as asymmetric key material below and can never fall back to
-  // being used as an HMAC secret.
-  const pemStart = trimmedKey.search(pemBeginMatcher)
+  const { pem, isRawSecret } = locatePem(trimmedKey)
 
-  if (pemStart === -1) {
+  if (isRawSecret) {
     return 'HS256'
   }
 
-  const pem = trimmedKey.slice(pemStart)
-
-  if (pem.match(publicKeyPemMatcher) || pem.includes(publicKeyX509CertMatcher)) {
+  if (pem.match(publicKeyPemMatcher) || pem.startsWith(publicKeyX509CertMatcher)) {
     throw new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
   }
 
@@ -155,18 +165,13 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
 function performDetectPublicKeyAlgorithms(key) {
   const trimmedKey = key.trim()
 
-  // Locate the PEM/certificate block wherever it starts. Only a key with no PEM
-  // header anywhere is treated as a raw HMAC secret; once a header is present it
-  // must be classified as asymmetric key material and can never fall back to
-  // HMAC, otherwise a public key would be usable as the HMAC shared secret.
-  const pemStart = trimmedKey.search(pemBeginMatcher)
+  const { pem, isRawSecret } = locatePem(trimmedKey)
 
-  if (pemStart === -1) {
+  if (isRawSecret) {
     // Not a PEM, assume a plain secret
     return hsAlgorithms
   }
 
-  const pem = trimmedKey.slice(pemStart)
   const publicKeyPemMatch = pem.match(publicKeyPemMatcher)
 
   if (pem.match(privateKeyPemMatcher)) {
@@ -174,11 +179,16 @@ function performDetectPublicKeyAlgorithms(key) {
   } else if (publicKeyPemMatch && publicKeyPemMatch[1] === 'RSA') {
     // pkcs1 format - Can only be RSA key
     return rsaAlgorithms
+  } else if (!publicKeyPemMatch && !pem.startsWith(publicKeyX509CertMatcher)) {
+    // The leading PEM header is neither a public key nor a certificate. Refuse
+    // rather than scanning past it (asn1 would) so this matches the private path
+    // exactly for junk-before-a-real-header input.
+    throw new TokenError(TokenError.codes.invalidKey, 'Unsupported PEM public key.')
   }
 
   // if the key is a X509 cert we need to convert it
   let resolvedKey = pem
-  if (pem.includes(publicKeyX509CertMatcher)) {
+  if (pem.startsWith(publicKeyX509CertMatcher)) {
     resolvedKey = createPublicKey(pem).export({ type: 'spki', format: 'pem' })
   }
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { describe, test } = require('node:test')
+const { createHmac } = require('node:crypto')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
@@ -77,6 +78,24 @@ T7r5sAUIWaF0Q5uk5NYmLOnCFxoP8Ua16sraCbAozdvg0wfvT7Cq
 
 const leadingWhitespacePrefixes = ['\n', ' ', ' \n', '\n ', '\t\t']
 
+// GHSA-ww5h-9m49-7xx4 (incomplete fix of CVE-2026-34950): `String.prototype.trim()`
+// only strips whitespace, so any NON-whitespace leading byte used to push the PEM
+// header off position 0 and defeat the ^-anchored matcher, causing an asymmetric
+// key to be misclassified as an HMAC secret (RSA -> HS256 algorithm confusion).
+const leadingNonWhitespacePrefixes = [
+  '# some comment\n', // comment line
+  '// comment\n',
+  '.', // arbitrary printable byte
+  'HTTP/1.1 200 OK\r\n\r\n', // HTTP-style header
+  String.fromCodePoint(0x00), // NUL
+  String.fromCodePoint(0x01), // SOH
+  String.fromCodePoint(0x1b), // ESC (ANSI escape)
+  String.fromCodePoint(0x7f), // DEL
+  String.fromCodePoint(0x200b), // zero-width space
+  String.fromCodePoint(0x200d), // zero-width joiner
+  String.fromCodePoint(0x180e) // Mongolian vowel separator
+]
+
 describe('detectPrivateKeyAlgorithm', () => {
   for (const type of ['HS', 'ES', 'RS', 'PS']) {
     for (const bits of [256, 384, 512]) {
@@ -146,6 +165,15 @@ describe('detectPrivateKeyAlgorithm', () => {
     })
   })
 
+  test('a key with an unrecognized PEM header must be refused (not used as a secret)', t => {
+    t.assert.throws(
+      () => detectPrivateKeyAlgorithm('# note\n-----BEGIN SOMETHING-----\nQUJD\n-----END SOMETHING-----'),
+      {
+        message: 'Unsupported PEM private key.'
+      }
+    )
+  })
+
   test('public keys should be accepted if HS256, HS384, HS512 is used', t => {
     ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
       t.assert.equal(
@@ -188,6 +216,31 @@ describe('detectPrivateKeyAlgorithm', () => {
 
   test('EC private key with leading whitespace must still be detected', t => {
     for (const prefix of leadingWhitespacePrefixes) {
+      t.assert.equal(detectPrivateKeyAlgorithm(prefix + privateKeys.ES256.toString('utf-8')), 'ES256')
+    }
+  })
+
+  // GHSA-ww5h-9m49-7xx4 (signer side): a non-whitespace prefix must not push the PEM
+  // header off position 0 and cause a public/private key to be treated as an HMAC secret.
+  test('public key with non-whitespace prefix must still be rejected', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPrivateKeyAlgorithm(prefix + publicKeys.RS.toString('utf-8')), {
+        message: 'Public keys are not supported for signing.'
+      })
+    }
+  })
+
+  test('X.509 cert with non-whitespace prefix must still be rejected', t => {
+    const cert = readFileSync(resolve(__dirname, '../benchmarks/keys/rs-x509-public.key'))
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPrivateKeyAlgorithm(prefix + cert.toString('utf-8')), {
+        message: 'Public keys are not supported for signing.'
+      })
+    }
+  })
+
+  test('EC private key with non-whitespace prefix must still be detected (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
       t.assert.equal(detectPrivateKeyAlgorithm(prefix + privateKeys.ES256.toString('utf-8')), 'ES256')
     }
   })
@@ -257,6 +310,15 @@ describe('detectPublicKeyAlgorithms', () => {
     })
   })
 
+  test('a key with an unrecognized PEM header must be refused (not used as a secret)', t => {
+    t.assert.throws(
+      () => detectPublicKeyAlgorithms('# note\n-----BEGIN SOMETHING-----\nQUJD\n-----END SOMETHING-----'),
+      {
+        message: 'Unsupported PEM public key.'
+      }
+    )
+  })
+
   test('public key-like strings should be accepted if all provided algorithms are HS', t => {
     ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
       t.assert.deepStrictEqual(
@@ -304,6 +366,67 @@ describe('detectPublicKeyAlgorithms', () => {
         message: 'Private keys are not supported for verifying.'
       })
     }
+  })
+
+  // GHSA-ww5h-9m49-7xx4: a non-whitespace prefix must not defeat detection and cause an
+  // asymmetric public key to be misclassified as an HMAC secret (RSA -> HS256 confusion).
+  test('RSA public key with non-whitespace prefix must be detected as RSA (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.RS.toString('utf-8')), rsaAlgorithms)
+    }
+  })
+
+  test('EC public key with non-whitespace prefix must be detected as EC (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.ES256.toString('utf-8')), ['ES256'])
+    }
+  })
+
+  test('Ed25519 public key with non-whitespace prefix must be detected as EdDSA (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.Ed25519.toString('utf-8')), ['EdDSA'])
+    }
+  })
+
+  test('private key with non-whitespace prefix must still be rejected', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPublicKeyAlgorithms(prefix + privateKeys.RS.toString('utf-8')), {
+        message: 'Private keys are not supported for verifying.'
+      })
+    }
+  })
+})
+
+// GHSA-ww5h-9m49-7xx4: end-to-end proof that the RSA -> HS256 algorithm-confusion
+// attack (forge an HS256 token whose signature is an HMAC keyed with the target's
+// RSA public key) is rejected even when the loaded key carries a non-whitespace prefix.
+describe('GHSA-ww5h-9m49-7xx4 - RSA to HS256 algorithm confusion via key prefix', () => {
+  function forgeHsToken(secret, alg = 'HS256') {
+    const header = Buffer.from(JSON.stringify({ alg, typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({ admin: true, sub: 'attacker' })).toString('base64url')
+    const signature = createHmac(`sha${alg.slice(2)}`, secret)
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    return `${header}.${payload}.${signature}`
+  }
+
+  test('a prefixed RSA public key must not be usable as an HMAC secret (default verifier)', t => {
+    const publicKey = publicKeys.RS.toString('utf-8')
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      const key = prefix + publicKey
+      const forged = forgeHsToken(key)
+      // No algorithms allowlist -> the key must be detected as RSA, so an HS256 token
+      // can never be accepted. Rejection may surface at verifier creation or at verify.
+      t.assert.throws(() => createVerifier({ key })(forged))
+    }
+  })
+
+  test('the clean (unprefixed) RSA public key is also not usable as an HMAC secret', t => {
+    const key = publicKeys.RS.toString('utf-8')
+    const forged = forgeHsToken(key)
+    t.assert.throws(() => createVerifier({ key })(forged), {
+      code: 'FAST_JWT_INVALID_ALGORITHM'
+    })
   })
 })
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -430,6 +430,26 @@ describe('GHSA-ww5h-9m49-7xx4 - RSA to HS256 algorithm confusion via key prefix'
   })
 })
 
+// GHSA-ww5h-9m49-7xx4 (review follow-up): the two detectors must agree on
+// junk-before-a-real-header input. A real key hidden behind an unrelated PEM
+// block must be refused by BOTH detectors (never classified as an HMAC secret),
+// so the paths cannot drift the way earlier fixes in this CVE lineage did.
+describe('GHSA-ww5h-9m49-7xx4 - detector consistency on junk PEM block before a real key', () => {
+  const junkBlock = '-----BEGIN COMMENT-----\nQUJD\n-----END COMMENT-----\n'
+
+  test('private-key detection refuses a real key behind a junk PEM block', t => {
+    t.assert.throws(() => detectPrivateKeyAlgorithm(junkBlock + privateKeys.RS.toString('utf-8')), {
+      message: 'Unsupported PEM private key.'
+    })
+  })
+
+  test('public-key detection refuses a real key behind a junk PEM block', t => {
+    t.assert.throws(() => detectPublicKeyAlgorithms(junkBlock + publicKeys.RS.toString('utf-8')), {
+      message: 'Unsupported PEM public key.'
+    })
+  })
+})
+
 for (const bits of [256, 384, 512]) {
   const hsAlgorithm = `HS${bits}`
   const key = privateKeys.HS


### PR DESCRIPTION
Closes #630

## Summary

Fixes **GHSA-ww5h-9m49-7xx4** (critical, CVSS 9.8) — an **incomplete fix of CVE-2026-34950** that re-enabled the RSA→HS256 algorithm-confusion attack in `fast-jwt` 6.2.x.

The v6.2.0 fix added `key.trim()` before the `^`-anchored PEM matchers in `src/crypto.js`, but `String.prototype.trim()` only strips whitespace. Any **non-whitespace** leading byte (control chars, zero-width unicode, `#`/`//` comments, HTTP/PGP wrappers, `.`, …) keeps the PEM header off position 0, so the anchored matcher fails and an RSA **public** key falls through to the HMAC path — where it is used as the HMAC shared secret. An attacker who knows the (public) verification key can then forge an `HS256` token whose signature is `HMAC(key=publicKey, header.payload)` and have it accepted as authentic.

Reproduced on `master` (6.2.4): 8/8 non-whitespace prefixes accepted a forged `{ admin: true }` token before this change; 0 after.

## Fix

Instead of anchoring detection at position 0, **locate the PEM/certificate header wherever it appears** (`pemBeginMatcher`) and classify from there:

- A key is treated as a raw HMAC secret **only** when it contains no PEM header at all (`pemStart === -1`).
- Once a header is present, the key must classify as asymmetric material and can **never** fall back to HMAC.
- A header that matches no supported key type is **refused** (throws) rather than silently used as a secret.
- Applied symmetrically to public-key (verify) and private-key (sign) detection.

This also aligns with RFC 7468 (leading explanatory text before `-----BEGIN` is tolerated and still resolves to the correct asymmetric algorithm). The intentional `algorithms: ['HS*']` escape hatch — where a caller explicitly opts into using a PEM-like string as a raw HMAC secret — is **unchanged**, since it returns before detection runs.

## Tests

- Non-whitespace prefix matrix (control bytes `0x00/0x01/0x1b/0x7f`, zero-width unicode `U+200B/U+200D/U+180E`, comment/HTTP wrappers) for **both** detectors, asserting asymmetric keys are classified correctly and never as HMAC.
- Unrecognized-PEM-header refusal for both detectors.
- End-to-end forgery regression: a prefixed RSA public key can no longer be used as an HMAC secret to forge an `HS256` token.

## Verification

- Full suite green: `npm run test:ci` (313 tests, lint, tstyche).
- `crypto.js` coverage maintained (new code fully covered).
- Independent security review found no residual bypass: the confusion attack requires a string that both classifies as HMAC *and* is accepted by Node's `createPublicKey`; no such dual-use string exists (OpenSSL rejects anything without a standard uppercase `-----BEGIN <LABEL>-----` boundary — exactly what the matcher detects).

## Breaking change

Keys that contain an **unrecognized** PEM header — or asymmetric key material presented in the wrong role via a leading prefix — now **throw** during key detection instead of being silently accepted as an HMAC secret. This affects only the pathological/insecure caller who fed an HMAC secret that literally contains a PEM header; well-formed HMAC secrets, PEM keys, and the explicit `algorithms: ['HS*']` opt-in are unaffected. Flagging for release notes.

> ⚠️ Coordinated disclosure: this addresses an as-yet-unpublished advisory. The patched release should be published together with (or ahead of) the advisory so there is no window where the exploit is public without a fixed version available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)