### PR TITLE
fix: reject raw asymmetric JWK/JWKS JSON used as an HMAC secret

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -27,6 +27,14 @@ const encoderMap = { '=': '', '+': '-', '/': '_' }
 const privateKeyPemMatcher = /^-----BEGIN(?: (RSA|EC|ENCRYPTED))? PRIVATE KEY-----/
 const publicKeyPemMatcher = /^-----BEGIN(?: (RSA))? PUBLIC KEY-----/
 const publicKeyX509CertMatcher = '-----BEGIN CERTIFICATE-----'
+// Matches any PEM/certificate header regardless of its position in the string.
+// Used to locate the start of a PEM block so that leading bytes (whitespace,
+// control chars, zero-width unicode, comments, wrappers, ...) cannot push the
+// header off position 0 and defeat the ^-anchored matchers above, which would
+// misclassify an asymmetric key as an HMAC secret (algorithm confusion —
+// GHSA-ww5h-9m49-7xx4, the incomplete-fix lineage of CVE-2023-48223 /
+// CVE-2026-34950).
+const pemBeginMatcher = /-----BEGIN [A-Z0-9 ]+?-----/
 const privateKeysCache = new Cache(1000)
 const publicKeysCache = new Cache(1000)
 
@@ -79,14 +87,28 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
     return providedAlgorithm
   }
 
-  if (trimmedKey.match(publicKeyPemMatcher) || trimmedKey.includes(publicKeyX509CertMatcher)) {
+  // Locate the PEM block wherever it starts. If there is no PEM/certificate
+  // header at all, this is a genuine raw HMAC secret. If there is one, it must
+  // be classified as asymmetric key material below and can never fall back to
+  // being used as an HMAC secret.
+  const pemStart = trimmedKey.search(pemBeginMatcher)
+
+  if (pemStart === -1) {
+    return 'HS256'
+  }
+
+  const pem = trimmedKey.slice(pemStart)
+
+  if (pem.match(publicKeyPemMatcher) || pem.includes(publicKeyX509CertMatcher)) {
     throw new TokenError(TokenError.codes.invalidKey, 'Public keys are not supported for signing.')
   }
 
-  const pemData = trimmedKey.match(privateKeyPemMatcher)
+  const pemData = pem.match(privateKeyPemMatcher)
 
   if (!pemData) {
-    return 'HS256'
+    // A PEM header is present but it is neither a supported private key nor a
+    // public key/certificate: refuse rather than silently using it as a secret.
+    throw new TokenError(TokenError.codes.invalidKey, 'Unsupported PEM private key.')
   }
 
   let keyData
@@ -97,14 +119,14 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
     case 'RSA': // pkcs1 format - Can only be RSA key
       return 'RS256'
     case 'EC': // sec1 format - Can only be a EC key
-      keyData = ECPrivateKey.decode(trimmedKey, 'pem', { label: 'EC PRIVATE KEY' })
+      keyData = ECPrivateKey.decode(pem, 'pem', { label: 'EC PRIVATE KEY' })
       curveId = keyData.parameters.value.join('.')
       break
     case 'ENCRYPTED': // Can be either RSA or EC key - we'll used the supplied algorithm
       return 'ENCRYPTED'
     default:
       // pkcs8
-      keyData = PrivateKey.decode(trimmedKey, 'pem', { label: 'PRIVATE KEY' })
+      keyData = PrivateKey.decode(pem, 'pem', { label: 'PRIVATE KEY' })
       oid = keyData.algorithm.algorithm.join('.')
 
       switch (oid) {
@@ -132,22 +154,32 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
 
 function performDetectPublicKeyAlgorithms(key) {
   const trimmedKey = key.trim()
-  const publicKeyPemMatch = trimmedKey.match(publicKeyPemMatcher)
 
-  if (trimmedKey.match(privateKeyPemMatcher)) {
-    throw new TokenError(TokenError.codes.invalidKey, 'Private keys are not supported for verifying.')
-  } else if (publicKeyPemMatch && publicKeyPemMatch[1] === 'RSA') {
-    // pkcs1 format - Can only be RSA key
-    return rsaAlgorithms
-  } else if (!publicKeyPemMatch && !trimmedKey.includes(publicKeyX509CertMatcher)) {
+  // Locate the PEM/certificate block wherever it starts. Only a key with no PEM
+  // header anywhere is treated as a raw HMAC secret; once a header is present it
+  // must be classified as asymmetric key material and can never fall back to
+  // HMAC, otherwise a public key would be usable as the HMAC shared secret.
+  const pemStart = trimmedKey.search(pemBeginMatcher)
+
+  if (pemStart === -1) {
     // Not a PEM, assume a plain secret
     return hsAlgorithms
   }
 
+  const pem = trimmedKey.slice(pemStart)
+  const publicKeyPemMatch = pem.match(publicKeyPemMatcher)
+
+  if (pem.match(privateKeyPemMatcher)) {
+    throw new TokenError(TokenError.codes.invalidKey, 'Private keys are not supported for verifying.')
+  } else if (publicKeyPemMatch && publicKeyPemMatch[1] === 'RSA') {
+    // pkcs1 format - Can only be RSA key
+    return rsaAlgorithms
+  }
+
   // if the key is a X509 cert we need to convert it
-  let resolvedKey = trimmedKey
-  if (trimmedKey.includes(publicKeyX509CertMatcher)) {
-    resolvedKey = createPublicKey(trimmedKey).export({ type: 'spki', format: 'pem' })
+  let resolvedKey = pem
+  if (pem.includes(publicKeyX509CertMatcher)) {
+    resolvedKey = createPublicKey(pem).export({ type: 'spki', format: 'pem' })
   }
 
   const keyData = PublicKey.decode(resolvedKey, 'pem', { label: 'PUBLIC KEY' })

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -35,6 +35,9 @@ const publicKeyX509CertMatcher = '-----BEGIN CERTIFICATE-----'
 // GHSA-ww5h-9m49-7xx4, the incomplete-fix lineage of CVE-2023-48223 /
 // CVE-2026-34950).
 const pemBeginMatcher = /-----BEGIN [A-Z0-9 ]+?-----/
+// kty values that identify asymmetric JWK key material (RFC 7518 / RFC 8037).
+// "oct" (a genuine symmetric key) is deliberately excluded so raw HS* JWKs keep working.
+const asymmetricJwkKtys = new Set(['RSA', 'EC', 'OKP'])
 const privateKeysCache = new Cache(1000)
 const publicKeysCache = new Cache(1000)
 
@@ -79,6 +82,30 @@ function cacheSet(cache, key, value, error) {
   return value || error
 }
 
+function isAsymmetricJwk(candidate) {
+  return Boolean(candidate) && typeof candidate === 'object' && asymmetricJwkKtys.has(candidate.kty)
+}
+
+// A serialized public (or private) JWK/JWKS has no PEM header, so it would otherwise
+// fall through to being treated as a raw HMAC secret -- letting an attacker who knows
+// the (public) JWK JSON forge an HS*-signed token (GHSA-g3jj-5cmm-3hxx). Detect the
+// asymmetric shape before that fallback and refuse it instead.
+function isAsymmetricJwkJson(trimmedKey) {
+  if (trimmedKey[0] !== '{') {
+    return false
+  }
+
+  let parsed
+
+  try {
+    parsed = JSON.parse(trimmedKey)
+  } catch {
+    return false
+  }
+
+  return isAsymmetricJwk(parsed) || (Array.isArray(parsed.keys) && parsed.keys.some(isAsymmetricJwk))
+}
+
 function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const trimmedKey = key.trim()
 
@@ -94,6 +121,13 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const pemStart = trimmedKey.search(pemBeginMatcher)
 
   if (pemStart === -1) {
+    if (isAsymmetricJwkJson(trimmedKey)) {
+      throw new TokenError(
+        TokenError.codes.invalidKey,
+        'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      )
+    }
+
     return 'HS256'
   }
 
@@ -162,6 +196,13 @@ function performDetectPublicKeyAlgorithms(key) {
   const pemStart = trimmedKey.search(pemBeginMatcher)
 
   if (pemStart === -1) {
+    if (isAsymmetricJwkJson(trimmedKey)) {
+      throw new TokenError(
+        TokenError.codes.invalidKey,
+        'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      )
+    }
+
     // Not a PEM, assume a plain secret
     return hsAlgorithms
   }

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { describe, test } = require('node:test')
+const { createHmac } = require('node:crypto')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
@@ -77,6 +78,24 @@ T7r5sAUIWaF0Q5uk5NYmLOnCFxoP8Ua16sraCbAozdvg0wfvT7Cq
 
 const leadingWhitespacePrefixes = ['\n', ' ', ' \n', '\n ', '\t\t']
 
+// GHSA-ww5h-9m49-7xx4 (incomplete fix of CVE-2026-34950): `String.prototype.trim()`
+// only strips whitespace, so any NON-whitespace leading byte used to push the PEM
+// header off position 0 and defeat the ^-anchored matcher, causing an asymmetric
+// key to be misclassified as an HMAC secret (RSA -> HS256 algorithm confusion).
+const leadingNonWhitespacePrefixes = [
+  '# some comment\n', // comment line
+  '// comment\n',
+  '.', // arbitrary printable byte
+  'HTTP/1.1 200 OK\r\n\r\n', // HTTP-style header
+  String.fromCodePoint(0x00), // NUL
+  String.fromCodePoint(0x01), // SOH
+  String.fromCodePoint(0x1b), // ESC (ANSI escape)
+  String.fromCodePoint(0x7f), // DEL
+  String.fromCodePoint(0x200b), // zero-width space
+  String.fromCodePoint(0x200d), // zero-width joiner
+  String.fromCodePoint(0x180e) // Mongolian vowel separator
+]
+
 describe('detectPrivateKeyAlgorithm', () => {
   for (const type of ['HS', 'ES', 'RS', 'PS']) {
     for (const bits of [256, 384, 512]) {
@@ -146,6 +165,15 @@ describe('detectPrivateKeyAlgorithm', () => {
     })
   })
 
+  test('a key with an unrecognized PEM header must be refused (not used as a secret)', t => {
+    t.assert.throws(
+      () => detectPrivateKeyAlgorithm('# note\n-----BEGIN SOMETHING-----\nQUJD\n-----END SOMETHING-----'),
+      {
+        message: 'Unsupported PEM private key.'
+      }
+    )
+  })
+
   test('public keys should be accepted if HS256, HS384, HS512 is used', t => {
     ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
       t.assert.equal(
@@ -188,6 +216,31 @@ describe('detectPrivateKeyAlgorithm', () => {
 
   test('EC private key with leading whitespace must still be detected', t => {
     for (const prefix of leadingWhitespacePrefixes) {
+      t.assert.equal(detectPrivateKeyAlgorithm(prefix + privateKeys.ES256.toString('utf-8')), 'ES256')
+    }
+  })
+
+  // GHSA-ww5h-9m49-7xx4 (signer side): a non-whitespace prefix must not push the PEM
+  // header off position 0 and cause a public/private key to be treated as an HMAC secret.
+  test('public key with non-whitespace prefix must still be rejected', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPrivateKeyAlgorithm(prefix + publicKeys.RS.toString('utf-8')), {
+        message: 'Public keys are not supported for signing.'
+      })
+    }
+  })
+
+  test('X.509 cert with non-whitespace prefix must still be rejected', t => {
+    const cert = readFileSync(resolve(__dirname, '../benchmarks/keys/rs-x509-public.key'))
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPrivateKeyAlgorithm(prefix + cert.toString('utf-8')), {
+        message: 'Public keys are not supported for signing.'
+      })
+    }
+  })
+
+  test('EC private key with non-whitespace prefix must still be detected (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
       t.assert.equal(detectPrivateKeyAlgorithm(prefix + privateKeys.ES256.toString('utf-8')), 'ES256')
     }
   })
@@ -257,6 +310,15 @@ describe('detectPublicKeyAlgorithms', () => {
     })
   })
 
+  test('a key with an unrecognized PEM header must be refused (not used as a secret)', t => {
+    t.assert.throws(
+      () => detectPublicKeyAlgorithms('# note\n-----BEGIN SOMETHING-----\nQUJD\n-----END SOMETHING-----'),
+      {
+        message: 'Unsupported PEM public key.'
+      }
+    )
+  })
+
   test('public key-like strings should be accepted if all provided algorithms are HS', t => {
     ;['HS256', 'HS384', 'HS512'].forEach(algorithm => {
       t.assert.deepStrictEqual(
@@ -304,6 +366,67 @@ describe('detectPublicKeyAlgorithms', () => {
         message: 'Private keys are not supported for verifying.'
       })
     }
+  })
+
+  // GHSA-ww5h-9m49-7xx4: a non-whitespace prefix must not defeat detection and cause an
+  // asymmetric public key to be misclassified as an HMAC secret (RSA -> HS256 confusion).
+  test('RSA public key with non-whitespace prefix must be detected as RSA (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.RS.toString('utf-8')), rsaAlgorithms)
+    }
+  })
+
+  test('EC public key with non-whitespace prefix must be detected as EC (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.ES256.toString('utf-8')), ['ES256'])
+    }
+  })
+
+  test('Ed25519 public key with non-whitespace prefix must be detected as EdDSA (not HMAC)', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(prefix + publicKeys.Ed25519.toString('utf-8')), ['EdDSA'])
+    }
+  })
+
+  test('private key with non-whitespace prefix must still be rejected', t => {
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      t.assert.throws(() => detectPublicKeyAlgorithms(prefix + privateKeys.RS.toString('utf-8')), {
+        message: 'Private keys are not supported for verifying.'
+      })
+    }
+  })
+})
+
+// GHSA-ww5h-9m49-7xx4: end-to-end proof that the RSA -> HS256 algorithm-confusion
+// attack (forge an HS256 token whose signature is an HMAC keyed with the target's
+// RSA public key) is rejected even when the loaded key carries a non-whitespace prefix.
+describe('GHSA-ww5h-9m49-7xx4 - RSA to HS256 algorithm confusion via key prefix', () => {
+  function forgeHsToken(secret, alg = 'HS256') {
+    const header = Buffer.from(JSON.stringify({ alg, typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({ admin: true, sub: 'attacker' })).toString('base64url')
+    const signature = createHmac(`sha${alg.slice(2)}`, secret)
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    return `${header}.${payload}.${signature}`
+  }
+
+  test('a prefixed RSA public key must not be usable as an HMAC secret (default verifier)', t => {
+    const publicKey = publicKeys.RS.toString('utf-8')
+    for (const prefix of leadingNonWhitespacePrefixes) {
+      const key = prefix + publicKey
+      const forged = forgeHsToken(key)
+      // No algorithms allowlist -> the key must be detected as RSA, so an HS256 token
+      // can never be accepted. Rejection may surface at verifier creation or at verify.
+      t.assert.throws(() => createVerifier({ key })(forged))
+    }
+  })
+
+  test('the clean (unprefixed) RSA public key is also not usable as an HMAC secret', t => {
+    const key = publicKeys.RS.toString('utf-8')
+    const forged = forgeHsToken(key)
+    t.assert.throws(() => createVerifier({ key })(forged), {
+      code: 'FAST_JWT_INVALID_ALGORITHM'
+    })
   })
 })
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, test } = require('node:test')
-const { createHmac } = require('node:crypto')
+const { createHmac, generateKeyPairSync } = require('node:crypto')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
@@ -172,6 +172,24 @@ describe('detectPrivateKeyAlgorithm', () => {
         message: 'Unsupported PEM private key.'
       }
     )
+  })
+
+  // GHSA-g3jj-5cmm-3hxx: a raw JWK/JWKS JSON string has no PEM header and must not be
+  // usable as an HMAC secret when signing, matching the verify-side fix.
+  test('a raw asymmetric JWK JSON key must be refused (not used as a secret)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const jwk = publicKey.export({ format: 'jwk' })
+
+    t.assert.throws(() => detectPrivateKeyAlgorithm(JSON.stringify(jwk)), {
+      message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+    })
+  })
+
+  test('a raw asymmetric JWK JSON key is accepted as a secret when HS256 is explicitly requested', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const jwk = publicKey.export({ format: 'jwk' })
+
+    t.assert.equal(detectPrivateKeyAlgorithm(JSON.stringify(jwk), 'HS256'), 'HS256')
   })
 
   test('public keys should be accepted if HS256, HS384, HS512 is used', t => {
@@ -395,6 +413,67 @@ describe('detectPublicKeyAlgorithms', () => {
       })
     }
   })
+
+  // GHSA-g3jj-5cmm-3hxx: a serialized public JWK/JWKS has no PEM header, so it must not
+  // fall through to being treated as a raw HMAC secret (RSA -> HS256 confusion via JWK JSON).
+  describe('raw JWK/JWKS JSON must never be usable as an HMAC secret', () => {
+    for (const kty of ['RSA', 'EC', 'OKP']) {
+      test(`rejects a compact serialized public JWK with kty=${kty}`, t => {
+        const { publicKey } =
+          kty === 'RSA'
+            ? generateKeyPairSync('rsa', { modulusLength: 2048 })
+            : kty === 'EC'
+              ? generateKeyPairSync('ec', { namedCurve: 'P-256' })
+              : generateKeyPairSync('ed25519')
+        const jwk = { ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' }
+
+        t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwk)), {
+          message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+        })
+      })
+    }
+
+    test('rejects a pretty-printed public JWK', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwk = publicKey.export({ format: 'jwk' })
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwk, null, 2)), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('rejects a JWKS containing an asymmetric key', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwks = { keys: [publicKey.export({ format: 'jwk' })] }
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwks)), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('rejects a JWK/JWKS with leading or trailing whitespace', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwk = publicKey.export({ format: 'jwk' })
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(`\n  ${JSON.stringify(jwk)}\n\t`), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('a genuine symmetric (kty=oct) JWK is still usable as an HMAC secret', t => {
+      const jwk = { kty: 'oct', k: 'c2VjcmV0c2VjcmV0c2VjcmV0' }
+
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(JSON.stringify(jwk)), hsAlgorithms)
+    })
+
+    test('a plain non-JSON string is still usable as an HMAC secret', t => {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms('some-plain-secret'), hsAlgorithms)
+    })
+
+    test('malformed JSON-looking text falls back to a plain secret without throwing', t => {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms('{not valid json'), hsAlgorithms)
+    })
+  })
 })
 
 // GHSA-ww5h-9m49-7xx4: end-to-end proof that the RSA -> HS256 algorithm-confusion
@@ -427,6 +506,35 @@ describe('GHSA-ww5h-9m49-7xx4 - RSA to HS256 algorithm confusion via key prefix'
     t.assert.throws(() => createVerifier({ key })(forged), {
       code: 'FAST_JWT_INVALID_ALGORITHM'
     })
+  })
+})
+
+// GHSA-g3jj-5cmm-3hxx: end-to-end proof that a raw public JWK JSON string cannot be used
+// to forge an HS256 token, even though it is public-by-design and known to an attacker.
+describe('GHSA-g3jj-5cmm-3hxx - RSA to HS256 algorithm confusion via raw JWK JSON', () => {
+  function forgeHsToken(secret, alg = 'HS256') {
+    const header = Buffer.from(JSON.stringify({ alg, typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({ admin: true, sub: 'attacker' })).toString('base64url')
+    const signature = createHmac(`sha${alg.slice(2)}`, secret)
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    return `${header}.${payload}.${signature}`
+  }
+
+  test('a raw public JWK string must not be usable as an HMAC secret (mixed allowlist)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const key = JSON.stringify({ ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' })
+    const forged = forgeHsToken(key)
+
+    t.assert.throws(() => createVerifier({ key, algorithms: ['HS256', 'RS256'] })(forged))
+  })
+
+  test('a raw public JWK string must not be usable as an HMAC secret (inferred algorithms)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const key = JSON.stringify({ ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' })
+    const forged = forgeHsToken(key)
+
+    t.assert.throws(() => createVerifier({ key })(forged))
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes #634 (GHSA-g3jj-5cmm-3hxx): a serialized public JWK/JWKS is valid JSON but has no PEM header, so it fell through to the "not a PEM, assume a plain secret" fallback in key detection. Since public JWK material is public by design, an attacker who knows the same JSON text used as a verifier's key could forge an HS256-signed token with arbitrary claims.
- Detect JSON that parses to an asymmetric JWK (`kty: RSA`, `EC`, or `OKP`) or a JWKS (`keys` array containing one) before that fallback, and refuse it. Symmetric `kty: oct` JWKs and plain opaque-string secrets are unaffected and continue to work as HMAC secrets. Applied to both the verify path (the reported vector) and the sign path.
- Also includes the earlier `f35c2a0` fix on this branch (non-whitespace key-prefix bypass, GHSA-ww5h-9m49-7xx4).

## Test plan
- [x] `node --test test/crypto.spec.js` — 116/116 passing, including new regression tests for compact/pretty-printed JWKs, JWKS arrays, whitespace variants, `oct`/plain-secret non-regression, and end-to-end forgery tests reproducing the advisory PoC
- [x] Full suite: `npm test` — 326/326 passing
- [x] `npx eslint src/crypto.js test/crypto.spec.js` — clean
- [x] Verified the reported PoC (mixed `['HS256','RS256']` allowlist and inferred-algorithm configurations) now throws instead of accepting the forged token
- [x] Benchmarked `verify`/`sign` before and after — no measurable throughput/latency regression (new check short-circuits on a single character comparison for all non-JSON key shapes)

Fixes #634