### PR TITLE
fix: reject raw asymmetric JWK/JWKS JSON used as an HMAC secret

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -91,7 +91,11 @@ function isAsymmetricJwk(candidate) {
 // the (public) JWK JSON forge an HS*-signed token (GHSA-g3jj-5cmm-3hxx). Detect the
 // asymmetric shape before that fallback and refuse it instead.
 function isAsymmetricJwkJson(trimmedKey) {
-  if (trimmedKey[0] !== '{') {
+  const firstChar = trimmedKey[0]
+
+  // `[` covers the edge case of a caller serializing a JWKS' `keys` array rather
+  // than the wrapping document.
+  if (firstChar !== '{' && firstChar !== '[') {
     return false
   }
 
@@ -103,7 +107,11 @@ function isAsymmetricJwkJson(trimmedKey) {
     return false
   }
 
-  return isAsymmetricJwk(parsed) || (Array.isArray(parsed.keys) && parsed.keys.some(isAsymmetricJwk))
+  return (
+    isAsymmetricJwk(parsed) ||
+    (Array.isArray(parsed) && parsed.some(isAsymmetricJwk)) ||
+    (Array.isArray(parsed.keys) && parsed.keys.some(isAsymmetricJwk))
+  )
 }
 
 // Single source of truth for locating a PEM/certificate block. Returns the key

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -27,6 +27,9 @@ const encoderMap = { '=': '', '+': '-', '/': '_' }
 const privateKeyPemMatcher = /^-----BEGIN(?: (RSA|EC|ENCRYPTED))? PRIVATE KEY-----/
 const publicKeyPemMatcher = /^-----BEGIN(?: (RSA))? PUBLIC KEY-----/
 const publicKeyX509CertMatcher = '-----BEGIN CERTIFICATE-----'
+// kty values that identify asymmetric JWK key material (RFC 7518 / RFC 8037).
+// "oct" (a genuine symmetric key) is deliberately excluded so raw HS* JWKs keep working.
+const asymmetricJwkKtys = new Set(['RSA', 'EC', 'OKP'])
 const privateKeysCache = new Cache(1000)
 const publicKeysCache = new Cache(1000)
 
@@ -71,6 +74,30 @@ function cacheSet(cache, key, value, error) {
   return value || error
 }
 
+function isAsymmetricJwk(candidate) {
+  return Boolean(candidate) && typeof candidate === 'object' && asymmetricJwkKtys.has(candidate.kty)
+}
+
+// A serialized public (or private) JWK/JWKS has no PEM header, so it would otherwise
+// fall through to being treated as a raw HMAC secret -- letting an attacker who knows
+// the (public) JWK JSON forge an HS*-signed token (GHSA-g3jj-5cmm-3hxx). Detect the
+// asymmetric shape before that fallback and refuse it instead.
+function isAsymmetricJwkJson(trimmedKey) {
+  if (trimmedKey[0] !== '{') {
+    return false
+  }
+
+  let parsed
+
+  try {
+    parsed = JSON.parse(trimmedKey)
+  } catch {
+    return false
+  }
+
+  return isAsymmetricJwk(parsed) || (Array.isArray(parsed.keys) && parsed.keys.some(isAsymmetricJwk))
+}
+
 function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const trimmedKey = key.trim()
 
@@ -86,6 +113,13 @@ function performDetectPrivateKeyAlgorithm(key, providedAlgorithm) {
   const pemData = trimmedKey.match(privateKeyPemMatcher)
 
   if (!pemData) {
+    if (isAsymmetricJwkJson(trimmedKey)) {
+      throw new TokenError(
+        TokenError.codes.invalidKey,
+        'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      )
+    }
+
     return 'HS256'
   }
 
@@ -140,6 +174,13 @@ function performDetectPublicKeyAlgorithms(key) {
     // pkcs1 format - Can only be RSA key
     return rsaAlgorithms
   } else if (!publicKeyPemMatch && !trimmedKey.includes(publicKeyX509CertMatcher)) {
+    if (isAsymmetricJwkJson(trimmedKey)) {
+      throw new TokenError(
+        TokenError.codes.invalidKey,
+        'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      )
+    }
+
     // Not a PEM, assume a plain secret
     return hsAlgorithms
   }

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { describe, test } = require('node:test')
+const { createHmac, generateKeyPairSync } = require('node:crypto')
 const { readFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
@@ -191,6 +192,24 @@ describe('detectPrivateKeyAlgorithm', () => {
       t.assert.equal(detectPrivateKeyAlgorithm(prefix + privateKeys.ES256.toString('utf-8')), 'ES256')
     }
   })
+
+  // GHSA-g3jj-5cmm-3hxx: a raw JWK/JWKS JSON string has no PEM header and must not be
+  // usable as an HMAC secret when signing, matching the verify-side fix.
+  test('a raw asymmetric JWK JSON key must be refused (not used as a secret)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const jwk = publicKey.export({ format: 'jwk' })
+
+    t.assert.throws(() => detectPrivateKeyAlgorithm(JSON.stringify(jwk)), {
+      message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+    })
+  })
+
+  test('a raw asymmetric JWK JSON key is accepted as a secret when HS256 is explicitly requested', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const jwk = publicKey.export({ format: 'jwk' })
+
+    t.assert.equal(detectPrivateKeyAlgorithm(JSON.stringify(jwk), 'HS256'), 'HS256')
+  })
 })
 
 describe('detectPublicKeyAlgorithms', () => {
@@ -304,6 +323,96 @@ describe('detectPublicKeyAlgorithms', () => {
         message: 'Private keys are not supported for verifying.'
       })
     }
+  })
+
+  // GHSA-g3jj-5cmm-3hxx: a serialized public JWK/JWKS has no PEM header, so it must not
+  // fall through to being treated as a raw HMAC secret (RSA -> HS256 confusion via JWK JSON).
+  describe('raw JWK/JWKS JSON must never be usable as an HMAC secret', () => {
+    for (const kty of ['RSA', 'EC', 'OKP']) {
+      test(`rejects a compact serialized public JWK with kty=${kty}`, t => {
+        const { publicKey } =
+          kty === 'RSA'
+            ? generateKeyPairSync('rsa', { modulusLength: 2048 })
+            : kty === 'EC'
+              ? generateKeyPairSync('ec', { namedCurve: 'P-256' })
+              : generateKeyPairSync('ed25519')
+        const jwk = { ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' }
+
+        t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwk)), {
+          message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+        })
+      })
+    }
+
+    test('rejects a pretty-printed public JWK', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwk = publicKey.export({ format: 'jwk' })
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwk, null, 2)), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('rejects a JWKS containing an asymmetric key', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwks = { keys: [publicKey.export({ format: 'jwk' })] }
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(jwks)), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('rejects a JWK/JWKS with leading or trailing whitespace', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const jwk = publicKey.export({ format: 'jwk' })
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(`\n  ${JSON.stringify(jwk)}\n\t`), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('a genuine symmetric (kty=oct) JWK is still usable as an HMAC secret', t => {
+      const jwk = { kty: 'oct', k: 'c2VjcmV0c2VjcmV0c2VjcmV0' }
+
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(JSON.stringify(jwk)), hsAlgorithms)
+    })
+
+    test('a plain non-JSON string is still usable as an HMAC secret', t => {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms('some-plain-secret'), hsAlgorithms)
+    })
+
+    test('malformed JSON-looking text falls back to a plain secret without throwing', t => {
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms('{not valid json'), hsAlgorithms)
+    })
+  })
+})
+
+// GHSA-g3jj-5cmm-3hxx: end-to-end proof that a raw public JWK JSON string cannot be used
+// to forge an HS256 token, even though it is public-by-design and known to an attacker.
+describe('GHSA-g3jj-5cmm-3hxx - RSA to HS256 algorithm confusion via raw JWK JSON', () => {
+  function forgeHsToken(secret, alg = 'HS256') {
+    const header = Buffer.from(JSON.stringify({ alg, typ: 'JWT' })).toString('base64url')
+    const payload = Buffer.from(JSON.stringify({ admin: true, sub: 'attacker' })).toString('base64url')
+    const signature = createHmac(`sha${alg.slice(2)}`, secret)
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    return `${header}.${payload}.${signature}`
+  }
+
+  test('a raw public JWK string must not be usable as an HMAC secret (mixed allowlist)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const key = JSON.stringify({ ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' })
+    const forged = forgeHsToken(key)
+
+    t.assert.throws(() => createVerifier({ key, algorithms: ['HS256', 'RS256'] })(forged))
+  })
+
+  test('a raw public JWK string must not be usable as an HMAC secret (inferred algorithms)', t => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const key = JSON.stringify({ ...publicKey.export({ format: 'jwk' }), kid: 'test', use: 'sig' })
+    const forged = forgeHsToken(key)
+
+    t.assert.throws(() => createVerifier({ key })(forged))
   })
 })
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -427,6 +427,21 @@ describe('detectPublicKeyAlgorithms', () => {
       })
     })
 
+    test('rejects a bare array of JWKs (a JWKS\' `keys` serialized without its wrapper)', t => {
+      const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+      const keys = [publicKey.export({ format: 'jwk' })]
+
+      t.assert.throws(() => detectPublicKeyAlgorithms(JSON.stringify(keys)), {
+        message: 'Raw asymmetric JWK/JWKS JSON cannot be used as an HMAC secret.'
+      })
+    })
+
+    test('a bare array of symmetric (kty=oct) JWKs is still usable as an HMAC secret', t => {
+      const keys = [{ kty: 'oct', k: 'c2VjcmV0c2VjcmV0c2VjcmV0' }]
+
+      t.assert.deepStrictEqual(detectPublicKeyAlgorithms(JSON.stringify(keys)), hsAlgorithms)
+    })
+
     test('rejects a JWK/JWKS with leading or trailing whitespace', t => {
       const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
       const jwk = publicKey.export({ format: 'jwk' })

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -427,7 +427,7 @@ describe('detectPublicKeyAlgorithms', () => {
       })
     })
 
-    test('rejects a bare array of JWKs (a JWKS\' `keys` serialized without its wrapper)', t => {
+    test("rejects a bare array of JWKs (a JWKS' `keys` serialized without its wrapper)", t => {
       const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
       const keys = [publicKey.export({ format: 'jwk' })]
 

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -193,9 +193,10 @@ describe('detectPrivateKeyAlgorithm', () => {
     }
   })
 
-  // GHSA-g3jj-5cmm-3hxx: a raw JWK/JWKS JSON string has no PEM header and must not be
-  // usable as an HMAC secret when signing, matching the verify-side fix.
-  test('a raw asymmetric JWK JSON key must be refused (not used as a secret)', t => {
+  // GHSA-g3jj-5cmm-3hxx: a raw JWK/JWKS JSON string has no PEM header, so automatic
+  // algorithm detection must not treat it as a plain HMAC secret, matching the
+  // verify-side fix.
+  test('a raw asymmetric JWK JSON key must be refused by automatic detection', t => {
     const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
     const jwk = publicKey.export({ format: 'jwk' })
 
@@ -204,6 +205,9 @@ describe('detectPrivateKeyAlgorithm', () => {
     })
   })
 
+  // Pre-existing escape hatch (unchanged by this fix, same as for PEM-shaped keys above):
+  // explicitly forcing an HS* algorithm skips detection entirely and uses the string
+  // as-is, since the caller is asserting the key is a raw secret.
   test('a raw asymmetric JWK JSON key is accepted as a secret when HS256 is explicitly requested', t => {
     const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
     const jwk = publicKey.export({ format: 'jwk' })


### PR DESCRIPTION
## Summary
- Fixes #634 (GHSA-g3jj-5cmm-3hxx): a serialized public JWK/JWKS is valid JSON but has no PEM header, so it fell through to the "not a PEM, assume a plain secret" fallback in key detection. Since public JWK material is public by design, an attacker who knows the same JSON text used as a verifier's key could forge an HS256-signed token with arbitrary claims.
- Detect JSON that parses to an asymmetric JWK (`kty: RSA`, `EC`, or `OKP`) or a JWKS (`keys` array containing one) before that fallback, and refuse it. Symmetric `kty: oct` JWKs and plain opaque-string secrets are unaffected and continue to work as HMAC secrets. Applied to both the verify path (the reported vector) and the sign path.

## Test plan
- [x] `node --test test/crypto.spec.js` — 105/105 passing, including new regression tests for compact/pretty-printed JWKs, JWKS arrays, whitespace variants, `oct`/plain-secret non-regression, and end-to-end forgery tests reproducing the advisory PoC
- [x] Full suite: `npm test` — 315/315 passing
- [x] `npx eslint src/crypto.js test/crypto.spec.js` — clean
- [x] Verified the reported PoC (mixed `['HS256','RS256']` allowlist and inferred-algorithm configurations) now throws instead of accepting the forged token
- [x] Benchmarked `verify`/`sign` before and after — no measurable throughput/latency regression (new check short-circuits on a single character comparison for all non-JSON key shapes)

Fixes #634