### PR TITLE
fix: reject JSON array payloads in decoder

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -62,7 +62,7 @@ function decode({ complete, checkTyp }, token) {
     // 10.  Verify that the resulting octet sequence is a UTF-8-encoded
     //      representation of a completely valid JSON object conforming to
     //      RFC 7159 [RFC7159]; let the JWT Claims Set be this JSON object.
-    if (!payload || typeof payload !== 'object') {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       throw new TokenError(TokenError.codes.invalidPayload, 'The payload must be an object', { payload })
     }
 

--- a/test/decoder.spec.js
+++ b/test/decoder.spec.js
@@ -104,6 +104,12 @@ describe('createDecoder', () => {
         message: 'The payload must be an object'
       }
     )
+
+    // array - typeof [] === 'object', so this must be rejected explicitly
+    const arrayPayloadToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${Buffer.from('["a","b"]').toString('base64url')}.x`
+    t.assert.throws(() => defaultDecoder(arrayPayloadToken), {
+      message: 'The payload must be an object'
+    })
   })
 
   // https://datatracker.ietf.org/doc/html/rfc4648#section-3.3 - strict base64url

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -2368,4 +2368,31 @@ describe('createVerifier', () => {
       t.assert.strictEqual(payload.sub, 'asymmetric-user')
     })
   })
+
+  describe('array payload claim-validator bypass', () => {
+    function forgeArrayPayloadToken(key, payload = ['attacker', 'role:admin']) {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+      const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url')
+      const signingInput = `${header}.${encodedPayload}`
+      const signature = createHmac('sha256', key).update(signingInput).digest('base64url')
+
+      return `${signingInput}.${signature}`
+    }
+
+    test('rejects a validly-signed token whose payload is a JSON array instead of an object', t => {
+      const key = 'shared-secret'
+      const forgedToken = forgeArrayPayloadToken(key)
+
+      const verifier = createVerifier({
+        key,
+        allowedIss: ['legit-issuer'],
+        allowedAud: ['legit-audience'],
+        allowedSub: ['legit-subject']
+      })
+
+      t.assert.throws(() => verifier(forgedToken), {
+        message: 'The payload must be an object'
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- `typeof [] === 'object'` in JavaScript, so the decoder's payload type check (`typeof payload !== 'object'`) let a JSON array through as a valid payload.
- Downstream, claim validators test `claim in payload` to decide whether to enforce a rule. That test is always `false` for an array, so every configured validator (`exp`, `nbf`, `iss`, `aud`, `sub`, `jti`, `nonce`) was silently skipped when the payload was array-shaped.
- Adds an explicit `Array.isArray` check to the payload validation, mirroring the guard already in place for the header.

Closes #638

## Test plan
- [x] Added a decoder-level regression test asserting an array payload is rejected with `The payload must be an object`
- [x] Added a verifier-level regression test asserting a validly-signed array-payload token is rejected even when `allowedIss`/`allowedAud`/`allowedSub` are configured
- [x] Full test suite passes (303/303)
- [x] `eslint` clean on changed files