### PR TITLE
fix: reject non-finite clockTimestamp, clockTolerance and cacheTTL options

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -525,20 +525,20 @@ module.exports = function createVerifier(options) {
   }
 
   if (
-    clockTimestamp &&
+    clockTimestamp !== undefined &&
     (typeof clockTimestamp !== 'number' || !Number.isFinite(clockTimestamp) || clockTimestamp < 0)
   ) {
     throw new TokenError(TokenError.codes.invalidOption, 'The clockTimestamp option must be a finite positive number.')
   }
 
   if (
-    clockTolerance &&
+    clockTolerance !== undefined &&
     (typeof clockTolerance !== 'number' || !Number.isFinite(clockTolerance) || clockTolerance < 0)
   ) {
     throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a finite positive number.')
   }
 
-  if (cacheTTL && (typeof cacheTTL !== 'number' || !Number.isFinite(cacheTTL) || cacheTTL < 0)) {
+  if (cacheTTL !== undefined && (typeof cacheTTL !== 'number' || !Number.isFinite(cacheTTL) || cacheTTL < 0)) {
     throw new TokenError(TokenError.codes.invalidOption, 'The cacheTTL option must be a finite positive number.')
   }
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -528,18 +528,24 @@ module.exports = function createVerifier(options) {
     clockTimestamp !== undefined &&
     (typeof clockTimestamp !== 'number' || !Number.isFinite(clockTimestamp) || clockTimestamp < 0)
   ) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The clockTimestamp option must be a finite positive number.')
+    throw new TokenError(
+      TokenError.codes.invalidOption,
+      'The clockTimestamp option must be a finite, non-negative number.'
+    )
   }
 
   if (
     clockTolerance !== undefined &&
     (typeof clockTolerance !== 'number' || !Number.isFinite(clockTolerance) || clockTolerance < 0)
   ) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a finite positive number.')
+    throw new TokenError(
+      TokenError.codes.invalidOption,
+      'The clockTolerance option must be a finite, non-negative number.'
+    )
   }
 
   if (cacheTTL !== undefined && (typeof cacheTTL !== 'number' || !Number.isFinite(cacheTTL) || cacheTTL < 0)) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The cacheTTL option must be a finite positive number.')
+    throw new TokenError(TokenError.codes.invalidOption, 'The cacheTTL option must be a finite, non-negative number.')
   }
 
   if (

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -524,16 +524,22 @@ module.exports = function createVerifier(options) {
     key = prepareKeyOrSecret(key, hsAlgorithms.includes(availableAlgorithms[0]))
   }
 
-  if (clockTimestamp && (typeof clockTimestamp !== 'number' || clockTimestamp < 0)) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The clockTimestamp option must be a positive number.')
+  if (
+    clockTimestamp &&
+    (typeof clockTimestamp !== 'number' || !Number.isFinite(clockTimestamp) || clockTimestamp < 0)
+  ) {
+    throw new TokenError(TokenError.codes.invalidOption, 'The clockTimestamp option must be a finite positive number.')
   }
 
-  if (clockTolerance && (typeof clockTolerance !== 'number' || clockTolerance < 0)) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a positive number.')
+  if (
+    clockTolerance &&
+    (typeof clockTolerance !== 'number' || !Number.isFinite(clockTolerance) || clockTolerance < 0)
+  ) {
+    throw new TokenError(TokenError.codes.invalidOption, 'The clockTolerance option must be a finite positive number.')
   }
 
-  if (cacheTTL && (typeof cacheTTL !== 'number' || cacheTTL < 0)) {
-    throw new TokenError(TokenError.codes.invalidOption, 'The cacheTTL option must be a positive number.')
+  if (cacheTTL && (typeof cacheTTL !== 'number' || !Number.isFinite(cacheTTL) || cacheTTL < 0)) {
+    throw new TokenError(TokenError.codes.invalidOption, 'The cacheTTL option must be a finite positive number.')
   }
 
   if (

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1231,31 +1231,43 @@ describe('createVerifier', () => {
 
     test('clockTimestamp', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: '123' }), {
-        message: 'The clockTimestamp option must be a positive number.'
+        message: 'The clockTimestamp option must be a finite positive number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: -1 }), {
-        message: 'The clockTimestamp option must be a positive number.'
+        message: 'The clockTimestamp option must be a finite positive number.'
+      })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: Infinity }), {
+        message: 'The clockTimestamp option must be a finite positive number.'
       })
     })
 
     test('clockTolerance', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: '123' }), {
-        message: 'The clockTolerance option must be a positive number.'
+        message: 'The clockTolerance option must be a finite positive number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: -1 }), {
-        message: 'The clockTolerance option must be a positive number.'
+        message: 'The clockTolerance option must be a finite positive number.'
+      })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: Infinity }), {
+        message: 'The clockTolerance option must be a finite positive number.'
       })
     })
 
     test('cacheTTL', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: '123' }), {
-        message: 'The cacheTTL option must be a positive number.'
+        message: 'The cacheTTL option must be a finite positive number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: -1 }), {
-        message: 'The cacheTTL option must be a positive number.'
+        message: 'The cacheTTL option must be a finite positive number.'
+      })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: Infinity }), {
+        message: 'The cacheTTL option must be a finite positive number.'
       })
     })
 

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1241,6 +1241,10 @@ describe('createVerifier', () => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: Infinity }), {
         message: 'The clockTimestamp option must be a finite positive number.'
       })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: NaN }), {
+        message: 'The clockTimestamp option must be a finite positive number.'
+      })
     })
 
     test('clockTolerance', t => {
@@ -1255,6 +1259,10 @@ describe('createVerifier', () => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: Infinity }), {
         message: 'The clockTolerance option must be a finite positive number.'
       })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: NaN }), {
+        message: 'The clockTolerance option must be a finite positive number.'
+      })
     })
 
     test('cacheTTL', t => {
@@ -1267,6 +1275,10 @@ describe('createVerifier', () => {
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: Infinity }), {
+        message: 'The cacheTTL option must be a finite positive number.'
+      })
+
+      t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: NaN }), {
         message: 'The cacheTTL option must be a finite positive number.'
       })
     })

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -1231,55 +1231,55 @@ describe('createVerifier', () => {
 
     test('clockTimestamp', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: '123' }), {
-        message: 'The clockTimestamp option must be a finite positive number.'
+        message: 'The clockTimestamp option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: -1 }), {
-        message: 'The clockTimestamp option must be a finite positive number.'
+        message: 'The clockTimestamp option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: Infinity }), {
-        message: 'The clockTimestamp option must be a finite positive number.'
+        message: 'The clockTimestamp option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTimestamp: NaN }), {
-        message: 'The clockTimestamp option must be a finite positive number.'
+        message: 'The clockTimestamp option must be a finite, non-negative number.'
       })
     })
 
     test('clockTolerance', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: '123' }), {
-        message: 'The clockTolerance option must be a finite positive number.'
+        message: 'The clockTolerance option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: -1 }), {
-        message: 'The clockTolerance option must be a finite positive number.'
+        message: 'The clockTolerance option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: Infinity }), {
-        message: 'The clockTolerance option must be a finite positive number.'
+        message: 'The clockTolerance option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', clockTolerance: NaN }), {
-        message: 'The clockTolerance option must be a finite positive number.'
+        message: 'The clockTolerance option must be a finite, non-negative number.'
       })
     })
 
     test('cacheTTL', t => {
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: '123' }), {
-        message: 'The cacheTTL option must be a finite positive number.'
+        message: 'The cacheTTL option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: -1 }), {
-        message: 'The cacheTTL option must be a finite positive number.'
+        message: 'The cacheTTL option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: Infinity }), {
-        message: 'The cacheTTL option must be a finite positive number.'
+        message: 'The cacheTTL option must be a finite, non-negative number.'
       })
 
       t.assert.throws(() => createVerifier({ key: 'secret', cacheTTL: NaN }), {
-        message: 'The cacheTTL option must be a finite positive number.'
+        message: 'The cacheTTL option must be a finite, non-negative number.'
       })
     })
 


### PR DESCRIPTION
Closes #637

## Summary

`clockTimestamp`, `clockTolerance`, and `cacheTTL` on `createVerifier` were only validated as non-negative numbers, so `Infinity` passed the check. That value then flows into the `exp`/`nbf` comparison modifiers, effectively disabling expiry/not-before enforcement instead of being rejected as an invalid option.

This aligns the validation with `Number.isFinite()`, consistent with the guard already used for `expiresIn`/`notBefore` in `signer.js`.

## Changes

- `src/verifier.js`: add `!Number.isFinite(...)` to the `clockTimestamp`, `clockTolerance`, and `cacheTTL` option checks.
- `test/verifier.spec.js`: add `Infinity` cases to the existing options-validation tests for these three options.

## Test plan

- [x] `npm test` — full suite passes (302/302)
- [x] `npm run lint` — clean