### PR TITLE
fix: require a key unless the only allowed algorithm is "none" (GHSA-8wpc-h4q6-8fxv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const sections = decodeComplete(token)
 
 Create a verifier function by calling `createVerifier` and providing one or more of the following options:
 
-- `key`: A string or a buffer containing the secret for `HS*` algorithms or the PEM encoded public key for `RS*`, `PS*`, `ES*` and `EdDSA` algorithms. The key can also be a function accepting a Node style callback or a function returning a promise. This is the only mandatory option, which MUST NOT be provided if the token algorithm is `none`.
+- `key`: A string or a buffer containing the secret for `HS*` algorithms or the PEM encoded public key for `RS*`, `PS*`, `ES*` and `EdDSA` algorithms. The key can also be a function accepting a Node style callback or a function returning a promise. This option is mandatory unless `none` is the only allowed algorithm, in which case it MUST be omitted, an empty string or `null`. To verify unsigned tokens, omit the key and set `algorithms` to `['none']`. An empty string or `null` is rejected whenever any other algorithm is allowed.
 
 - `algorithms`: List of strings with the names of the allowed algorithms. By default, all algorithms are accepted.
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -504,10 +504,36 @@ module.exports = function createVerifier(options) {
   }
 
   const keyType = typeof key
-  if (keyType !== 'string' && keyType !== 'object' && keyType !== 'function') {
+  const allowsOnlyNone = allowedAlgorithms.length > 0 && allowedAlgorithms.every(algorithm => algorithm === 'none')
+
+  /*
+    Unsigned tokens carry no signature, so they are the only ones verifiable without a
+    key. Mirroring createSigner, only a truthy key is refused here: that stops a real
+    key from silently pairing with the "none" algorithm, while still accepting the
+    empty string and null that callers have long used to build such a verifier.
+  */
+  if (allowsOnlyNone) {
+    if (key) {
+      throw new TokenError(
+        TokenError.codes.invalidOption,
+        'The key option must not be provided when the only allowed algorithm is "none".'
+      )
+    }
+  } else if (keyType !== 'string' && keyType !== 'object' && keyType !== 'function') {
     throw new TokenError(
-      TokenError.codes.INVALID_OPTION,
+      TokenError.codes.invalidOption,
       'The key option must be a string, a buffer or a function returning the algorithm secret or public key.'
+    )
+  } else if (!key && keyType !== 'function') {
+    /*
+      An empty or null key can never verify a signature. Left unchecked, an explicit
+      allowlist would stay active with no key to check against: verifyToken sees
+      neither a key nor a signature, so it verifies nothing and accepts forged
+      unsigned tokens.
+    */
+    throw new TokenError(
+      TokenError.codes.invalidKey,
+      'The key option is required unless the only allowed algorithm is "none".'
     )
   }
 

--- a/test/verifier.spec.js
+++ b/test/verifier.spec.js
@@ -287,12 +287,18 @@ describe('createVerifier', () => {
       message: 'The token signature is missing.'
     })
 
+    // An empty key is now rejected when the verifier is built, so it can no longer
+    // reach the missing-key check at verify time. See the GHSA-8wpc-h4q6-8fxv suite
+    // for the construction-time contract and for a verifier that still reaches it.
     t.assert.throws(
       () =>
         verify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.57TF7smP9XDhIexBqPC-F1toZReYZLWb_YRU5tv0sxM', {
           key: ''
         }),
-      { message: 'The key option is missing.' }
+      {
+        code: 'FAST_JWT_INVALID_KEY',
+        message: 'The key option is required unless the only allowed algorithm is "none".'
+      }
     )
   })
 
@@ -1225,6 +1231,7 @@ describe('createVerifier', () => {
   describe('options validation', () => {
     test('key', t => {
       t.assert.throws(() => createVerifier({ key: 123 }), {
+        code: 'FAST_JWT_INVALID_OPTION',
         message: 'The key option must be a string, a buffer or a function returning the algorithm secret or public key.'
       })
     })
@@ -2352,23 +2359,18 @@ describe('createVerifier', () => {
       })
     })
 
-    test('regression case 11: synchronous empty key throws MISSING_KEY at verify time', t => {
-      const signer = createSigner({
-        key: 'valid-secret',
-        algorithm: 'HS256',
-        noTimestamp: true
-      })
-      const validToken = signer({ sub: 'user' })
-
-      const verifier = createVerifier({
-        key: '',
-        noTimestamp: true
-      })
-
-      t.assert.throws(() => verifier(validToken), {
-        code: 'FAST_JWT_MISSING_KEY',
-        message: 'The key option is missing.'
-      })
+    test('regression case 11: synchronous empty key is rejected when the verifier is built', t => {
+      t.assert.throws(
+        () =>
+          createVerifier({
+            key: '',
+            noTimestamp: true
+          }),
+        {
+          code: 'FAST_JWT_INVALID_KEY',
+          message: 'The key option is required unless the only allowed algorithm is "none".'
+        }
+      )
     })
 
     test('regression case 12: async resolver with valid RS256 public key verifies normally', async t => {
@@ -2416,6 +2418,149 @@ describe('createVerifier', () => {
 
       t.assert.throws(() => verifier(forgedToken), {
         message: 'The payload must be an object'
+      })
+    })
+  })
+
+  describe('GHSA-8wpc-h4q6-8fxv: falsy synchronous key with an explicit algorithms allowlist', () => {
+    function forgeUnsignedToken(algorithm, payload = { sub: 'attacker', admin: true }) {
+      const encodedHeader = Buffer.from(JSON.stringify({ alg: algorithm, typ: 'JWT' })).toString('base64url')
+      const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url')
+
+      // The trailing dot leaves the signature segment empty.
+      return `${encodedHeader}.${encodedPayload}.`
+    }
+
+    const expectedRejection = {
+      code: 'FAST_JWT_INVALID_KEY',
+      message: 'The key option is required unless the only allowed algorithm is "none".'
+    }
+
+    for (const emptyKey of ['', null]) {
+      const keyLabel = JSON.stringify(emptyKey)
+
+      for (const algorithm of ['HS256', 'HS512', 'RS256', 'PS256', 'ES256', 'EdDSA']) {
+        test(`rejects a verifier built with key ${keyLabel} and algorithms ['${algorithm}']`, t => {
+          t.assert.throws(() => createVerifier({ key: emptyKey, algorithms: [algorithm] }), expectedRejection)
+        })
+      }
+
+      test(`rejects a verifier built with key ${keyLabel} and a multi-algorithm allowlist`, t => {
+        t.assert.throws(() => createVerifier({ key: emptyKey, algorithms: ['HS256', 'RS256'] }), expectedRejection)
+      })
+
+      test(`rejects a verifier built with key ${keyLabel} and an allowlist mixing 'none' with a real algorithm`, t => {
+        t.assert.throws(() => createVerifier({ key: emptyKey, algorithms: ['none', 'HS256'] }), expectedRejection)
+        t.assert.throws(() => createVerifier({ key: emptyKey, algorithms: ['HS256', 'none'] }), expectedRejection)
+      })
+
+      test(`rejects a verifier built with key ${keyLabel} and no algorithms option`, t => {
+        t.assert.throws(() => createVerifier({ key: emptyKey }), expectedRejection)
+      })
+
+      test(`rejects a verifier built with key ${keyLabel} and a non-array algorithms option`, t => {
+        t.assert.throws(() => createVerifier({ key: emptyKey, algorithms: 'HS256' }), expectedRejection)
+      })
+
+      // Kept working for backwards compatibility: this was the only way to build a
+      // verifier for unsigned tokens before the key option could be omitted.
+      test(`still verifies an alg: none token with key ${keyLabel} and algorithms ['none']`, t => {
+        const unsignedToken = createSigner({ key: emptyKey, algorithm: 'none', noTimestamp: true })({
+          sub: 'anonymous'
+        })
+
+        const verifier = createVerifier({ key: emptyKey, algorithms: ['none'], noTimestamp: true })
+
+        t.assert.deepStrictEqual(verifier(unsignedToken), { sub: 'anonymous' })
+      })
+
+      test(`a none-only verifier with key ${keyLabel} still rejects an unsigned token of another algorithm`, t => {
+        const verifier = createVerifier({ key: emptyKey, algorithms: ['none'], noTimestamp: true })
+
+        t.assert.throws(() => verifier(forgeUnsignedToken('HS256')), {
+          code: 'FAST_JWT_INVALID_ALGORITHM',
+          message: 'The token algorithm is invalid.'
+        })
+      })
+    }
+
+    test("rejects a verifier built with an empty buffer key alongside algorithms ['none']", t => {
+      t.assert.throws(() => createVerifier({ key: Buffer.alloc(0), algorithms: ['none'] }), {
+        code: 'FAST_JWT_INVALID_OPTION',
+        message: 'The key option must not be provided when the only allowed algorithm is "none".'
+      })
+    })
+
+    test("rejects a verifier built with a real key alongside algorithms ['none']", t => {
+      t.assert.throws(() => createVerifier({ key: 'a-real-secret', algorithms: ['none'] }), {
+        code: 'FAST_JWT_INVALID_OPTION',
+        message: 'The key option must not be provided when the only allowed algorithm is "none".'
+      })
+    })
+
+    test("rejects a verifier built with a key function alongside algorithms ['none']", t => {
+      t.assert.throws(() => createVerifier({ key: async () => 'a-real-secret', algorithms: ['none'] }), {
+        code: 'FAST_JWT_INVALID_OPTION',
+        message: 'The key option must not be provided when the only allowed algorithm is "none".'
+      })
+    })
+
+    test("verifies an alg: none token when the key option is omitted and algorithms is ['none']", t => {
+      const unsignedToken = createSigner({ algorithm: 'none', noTimestamp: true })({ sub: 'anonymous' })
+
+      const verifier = createVerifier({ algorithms: ['none'], noTimestamp: true })
+
+      t.assert.deepStrictEqual(verifier(unsignedToken), { sub: 'anonymous' })
+    })
+
+    test('a none-only verifier rejects an unsigned token of another algorithm', t => {
+      const verifier = createVerifier({ algorithms: ['none'], noTimestamp: true })
+
+      t.assert.throws(() => verifier(forgeUnsignedToken('HS256')), {
+        code: 'FAST_JWT_INVALID_ALGORITHM',
+        message: 'The token algorithm is invalid.'
+      })
+    })
+
+    test('a none-only verifier rejects a token carrying a signature', t => {
+      const verifier = createVerifier({ algorithms: ['none'], noTimestamp: true })
+      const signedToken = `${forgeUnsignedToken('none')}AAAA`
+
+      t.assert.throws(() => verifier(signedToken), {
+        code: 'FAST_JWT_MISSING_KEY',
+        message: 'The key option is missing.'
+      })
+    })
+
+    test('does not reject a key function paired with an algorithms allowlist', async t => {
+      const key = 'a-real-secret'
+      const signedToken = createSigner({ key, algorithm: 'HS256', noTimestamp: true })({ sub: 'legit-user' })
+
+      const verifier = createVerifier({ key: async () => key, algorithms: ['HS256'], noTimestamp: true })
+
+      t.assert.deepStrictEqual(await verifier(signedToken), { sub: 'legit-user' })
+    })
+
+    test('still rejects an empty buffer key ahead of the allowlist check', t => {
+      t.assert.throws(() => createVerifier({ key: Buffer.alloc(0), algorithms: ['HS256'] }), {
+        code: 'FAST_JWT_INVALID_KEY',
+        message: 'The key cannot be an empty string or buffer.'
+      })
+    })
+
+    test('still rejects an undefined key as an invalid option', t => {
+      t.assert.throws(() => createVerifier({ algorithms: ['HS256'] }), {
+        code: 'FAST_JWT_INVALID_OPTION',
+        message: 'The key option must be a string, a buffer or a function returning the algorithm secret or public key.'
+      })
+    })
+
+    test('still reports a missing signature when a real key is configured', t => {
+      const verifier = createVerifier({ key: 'a-real-secret', algorithms: ['HS256'], noTimestamp: true })
+
+      t.assert.throws(() => verifier(forgeUnsignedToken('HS256')), {
+        code: 'FAST_JWT_MISSING_SIGNATURE',
+        message: 'The token signature is missing.'
       })
     })
   })


### PR DESCRIPTION
Closes #648

## Problem

`createVerifier` accepted an empty string or `null` as the `key`. The falsy-key branch skipped key preparation, so a caller-supplied `algorithms` allowlist stayed active with no key to check against. `verifyToken` then saw neither a key nor a signature, and verified nothing.

This predates the empty-secret hardening in #609 — it reproduces on v0.1.0, the first published release, and on every release since.

## Change

The `key` option is now validated when the verifier is built, rather than the falsy case falling through to verify time.

| configuration | before | after |
| --- | --- | --- |
| `''` / `null` + non-`none` allowlist | accepted, verified nothing | `INVALID_KEY` |
| `''` / `null` + no `algorithms` | `MISSING_KEY` at verify time | `INVALID_KEY` when built |
| key omitted + `algorithms: ['none']` | `INVALID_OPTION` | verifies unsigned tokens |
| `''` / `null` + `algorithms: ['none']` | verifies unsigned tokens | unchanged |
| truthy key or key function + `algorithms: ['none']` | `INVALID_KEY` from key detection, or failed per-token | `INVALID_OPTION` |
| real key + real allowlist | unchanged | unchanged |

When `none` is the only allowed algorithm, only a *truthy* key is refused, mirroring `createSigner`, which already rejects a key provided alongside `algorithm: "none"` and whose message is reused verbatim. `''` and `null` keep working there, since that was the only way to build a verifier for unsigned tokens before the key could be omitted — and a `none`-only verifier accepts nothing its caller did not explicitly allow.

This also makes `createVerifier({ algorithms: ['none'] })` work, which is the spelling the README has always documented but which previously threw `INVALID_OPTION`.

No breaking change: every configuration that worked before still works.

## Existing tests updated

Two tests asserted behaviour that has moved from verify time to construction time for an empty key:

- `requires a signature or a key` — the `key: ''` half now expects `INVALID_KEY` when the verifier is built.
- `regression case 11` — was named for a verify-time `MISSING_KEY` that an empty key can no longer reach. `MISSING_KEY` remains covered by a new test that gives a `none`-only verifier a token carrying a signature.

## Drive-by

`src/verifier.js` referenced `TokenError.codes.INVALID_OPTION`, which does not exist, so that error was thrown with `code: undefined`. Corrected to `invalidOption`, and the existing `options validation > key` test now asserts the code. It was the only uppercase code reference in the codebase.

## Tests

40 new tests covering the rejected configurations across `HS256`/`HS512`/`RS256`/`PS256`/`ES256`/`EdDSA` for both `''` and `null`, multi-algorithm and `none`-mixed allowlists, the `none`-only path for omitted/empty/null keys, and the unchanged paths (key functions, empty buffer, undefined key, real key with an unsigned token). Written before the fix; they failed 16/28 against the unpatched source at that point.

This is the first verifier-side coverage of `alg: none` in the repo — that gap is why #36 removed the original `no key implies none` fallback in 2020 as apparently-dead code.

`npm run lint` and `npm test` both pass: 363 tests, coverage for `src/verifier.js` at 99.42% lines / 98.79% branches, up from 99.40 / 98.73.
